### PR TITLE
Fix for IOTCLT-525.

### DIFF
--- a/nsdl-c/sn_nsdl_lib.h
+++ b/nsdl-c/sn_nsdl_lib.h
@@ -199,6 +199,8 @@ typedef struct sn_nsdl_resource_info_ {
 
     ns_list_link_t                  link;
 
+    uint8_t                         publish_uri;
+
 } sn_nsdl_resource_info_s;
 
 /**

--- a/source/libNsdl/src/sn_grs.c
+++ b/source/libNsdl/src/sn_grs.c
@@ -812,6 +812,7 @@ static int8_t sn_grs_add_resource_to_list(struct grs_s *handle, sn_nsdl_resource
     resource_copy_ptr->resourcelen = resource_ptr->resourcelen;
     resource_copy_ptr->sn_grs_dyn_res_callback = resource_ptr->sn_grs_dyn_res_callback;
     resource_copy_ptr->access = resource_ptr->access;
+    resource_copy_ptr->publish_uri = resource_ptr->publish_uri;
 
     /* Remove '/' - chars from the beginning and from the end */
 

--- a/source/libNsdl/src/sn_nsdl.c
+++ b/source/libNsdl/src/sn_nsdl.c
@@ -1188,7 +1188,7 @@ int8_t sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *mes
     /* Loop trough all resources */
     while (resource_temp_ptr) {
         /* if resource needs to be registered */
-        if (resource_temp_ptr->resource_parameters_ptr) {
+        if (resource_temp_ptr->resource_parameters_ptr && resource_temp_ptr->publish_uri) {
             if (updating_registeration && resource_temp_ptr->resource_parameters_ptr->registered == SN_NDSL_RESOURCE_REGISTERED) {
                 resource_temp_ptr = sn_grs_get_next_resource(handle->grs, resource_temp_ptr);
                 continue;

--- a/test/nsdl-c/unittest/sn_nsdl/test_sn_nsdl.c
+++ b/test/nsdl-c/unittest/sn_nsdl/test_sn_nsdl.c
@@ -295,6 +295,7 @@ bool test_sn_nsdl_register_endpoint()
     memset( sn_grs_stub.expectedInfo, 0, sizeof(sn_nsdl_resource_info_s));
     sn_grs_stub.expectedInfo->resource_parameters_ptr = (sn_nsdl_resource_parameters_s*)malloc(sizeof(sn_nsdl_resource_parameters_s));
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
+    sn_grs_stub.expectedInfo->publish_uri = 1;
     eptr->binding_and_mode = 0x06;
     retCounter = 4;
     //set_endpoint_info == -1
@@ -548,6 +549,7 @@ bool test_sn_nsdl_update_registration()
     sn_grs_stub.expectedInfo->resource_parameters_ptr = (sn_nsdl_resource_parameters_s*)malloc(sizeof(sn_nsdl_resource_parameters_s));
     memset( sn_grs_stub.expectedInfo->resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
+    sn_grs_stub.expectedInfo->publish_uri = 1;
     retCounter = 4;
     sn_grs_stub.expectedInfo->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_REGISTERING;
     //set_endpoint_info == -1
@@ -571,6 +573,7 @@ bool test_sn_nsdl_update_registration()
     sn_grs_stub.expectedInfo->resource_parameters_ptr = (sn_nsdl_resource_parameters_s*)malloc(sizeof(sn_nsdl_resource_parameters_s));
     memset( sn_grs_stub.expectedInfo->resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
+    sn_grs_stub.expectedInfo->publish_uri = 1;
     retCounter = 1;
     sn_grs_stub.expectedInfo->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_REGISTERING;
     //set_endpoint_info == -1
@@ -589,6 +592,7 @@ bool test_sn_nsdl_update_registration()
     sn_grs_stub.expectedInfo->resource_parameters_ptr = (sn_nsdl_resource_parameters_s*)malloc(sizeof(sn_nsdl_resource_parameters_s));
     memset( sn_grs_stub.expectedInfo->resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
+    sn_grs_stub.expectedInfo->publish_uri = 1;
     retCounter = 2;
     sn_grs_stub.expectedInfo->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_REGISTERING;
     //set_endpoint_info == -1

--- a/test/nsdl-c/unittest/sn_nsdl/test_sn_nsdl.c
+++ b/test/nsdl-c/unittest/sn_nsdl/test_sn_nsdl.c
@@ -272,6 +272,7 @@ bool test_sn_nsdl_register_endpoint()
     sn_grs_stub.expectedInfo->resource[0] = 'a';
     sn_grs_stub.expectedInfo->resource[1] = '\0';
     sn_grs_stub.expectedInfo->resourcelen = 1;
+    sn_grs_stub.expectedInfo->publish_uri = 1;
     //sn_nsdl_build_registration_body == SN_NSDL_FAILURE
     int8_t val = sn_nsdl_register_endpoint(handle, eptr);
 
@@ -342,6 +343,7 @@ bool test_sn_nsdl_register_endpoint()
     sn_grs_stub.expectedInfo->resource[0] = 'a';
     sn_grs_stub.expectedInfo->resource[1] = '\0';
     sn_grs_stub.expectedInfo->resourcelen = 1;
+    sn_grs_stub.expectedInfo->publish_uri = 1;
     eptr->binding_and_mode = 0x06;
     retCounter = 7;
 
@@ -507,6 +509,7 @@ bool test_sn_nsdl_update_registration()
     sn_grs_stub.expectedInfo->resource[0] = 'a';
     sn_grs_stub.expectedInfo->resource[1] = '\0';
     sn_grs_stub.expectedInfo->resourcelen = 1;
+    sn_grs_stub.expectedInfo->publish_uri = 1;
     int8_t val = sn_nsdl_update_registration(handle, NULL, 0);
 
     free(sn_grs_stub.expectedInfo->resource);


### PR DESCRIPTION
There is now feature that registered resources can be omitted from
registration message body that is sent to the server from client.