### PR TITLE
Enable message duplication by default

### DIFF
--- a/source/libCoap/src/include/sn_coap_protocol_internal.h
+++ b/source/libCoap/src/include/sn_coap_protocol_internal.h
@@ -57,19 +57,15 @@ struct sn_coap_hdr_;
 
 /* Init value for the maximum count of messages to be stored for duplication detection          */
 /* Setting of this value to 0 will disable duplication check, also reduce use of ROM memory     */
-
-// Keep the old flag to maintain backward compatibility
-#ifndef SN_COAP_DUPLICATION_MAX_MSGS_COUNT
-#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              0
-#endif
-
 #ifdef YOTTA_CFG_COAP_DUPLICATION_MAX_MSGS_COUNT
 #define SN_COAP_DUPLICATION_MAX_MSGS_COUNT YOTTA_CFG_COAP_DUPLICATION_MAX_MSGS_COUNT
 #elif defined MBED_CONF_MBED_CLIENT_SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 #define SN_COAP_DUPLICATION_MAX_MSGS_COUNT MBED_CONF_MBED_CLIENT_SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 #endif
 
-
+#ifndef SN_COAP_DUPLICATION_MAX_MSGS_COUNT
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              1
+#endif
 
 /* Maximum allowed number of saved messages for duplicate searching */
 #define SN_COAP_MAX_ALLOWED_DUPLICATION_MESSAGE_COUNT   6


### PR DESCRIPTION
Message duplication should be enabled by default otherwise it violates CoAP specification.
See discussion on https://github.com/ARMmbed/mbed-client-c/issues/45.