### PR TITLE
Fix for message duplication handling

### DIFF
--- a/source/libCoap/src/include/sn_coap_protocol_internal.h
+++ b/source/libCoap/src/include/sn_coap_protocol_internal.h
@@ -80,7 +80,7 @@ struct sn_coap_hdr_;
 
 // Keep the old flag to maintain backward compatibility
 #ifndef SN_COAP_DUPLICATION_MAX_MSGS_COUNT
-#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              0
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              1
 #endif
 
 #ifdef YOTTA_CFG_COAP_DUPLICATION_MAX_MSGS_COUNT

--- a/source/libCoap/src/sn_coap_protocol.c
+++ b/source/libCoap/src/sn_coap_protocol.c
@@ -610,29 +610,33 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
     /* * * * Manage received CoAP message duplicate detection  * * * */
 
     /* If no message duplication detected */
-    if (sn_coap_protocol_linked_list_duplication_info_search(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id) == -1) {
-        /* * * No Message duplication: Store received message for detecting later duplication * * */
+    if (returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE ||
+            returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_NON_CONFIRMABLE) {
 
-        /* Get count of stored duplication messages */
-        uint16_t stored_duplication_msgs_count = handle->count_duplication_msgs;
+        if (sn_coap_protocol_linked_list_duplication_info_search(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id) == -1) {
+            /* * * No Message duplication: Store received message for detecting later duplication * * */
 
-        /* Check if there is no room to store message for duplication detection purposes */
-        if (stored_duplication_msgs_count >= handle->sn_coap_duplication_buffer_size) {
-            /* Get oldest stored duplication message */
-            coap_duplication_info_s *stored_duplication_info_ptr = ns_list_get_first(&handle->linked_list_duplication_msgs);
+            /* Get count of stored duplication messages */
+            uint16_t stored_duplication_msgs_count = handle->count_duplication_msgs;
 
-            /* Remove oldest stored duplication message for getting room for new duplication message */
-            sn_coap_protocol_linked_list_duplication_info_remove(handle, stored_duplication_info_ptr->addr_ptr, stored_duplication_info_ptr->port, stored_duplication_info_ptr->msg_id);
+            /* Check if there is no room to store message for duplication detection purposes */
+            if (stored_duplication_msgs_count >= handle->sn_coap_duplication_buffer_size) {
+                /* Get oldest stored duplication message */
+                coap_duplication_info_s *stored_duplication_info_ptr = ns_list_get_first(&handle->linked_list_duplication_msgs);
+
+                /* Remove oldest stored duplication message for getting room for new duplication message */
+                sn_coap_protocol_linked_list_duplication_info_remove(handle, stored_duplication_info_ptr->addr_ptr, stored_duplication_info_ptr->port, stored_duplication_info_ptr->msg_id);
+            }
+
+            /* Store Duplication info to Linked list */
+            sn_coap_protocol_linked_list_duplication_info_store(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id);
+        } else { /* * * Message duplication detected * * */
+            /* Set returned status to User */
+            returned_dst_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_DUPLICATED_MSG;
+            // todo: send ACK to confirmable messages
+            /* Because duplicate message, return with coap_status set */
+            return returned_dst_coap_msg_ptr;
         }
-
-        /* Store Duplication info to Linked list */
-        sn_coap_protocol_linked_list_duplication_info_store(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id);
-    } else { /* * * Message duplication detected * * */
-        /* Set returned status to User */
-        returned_dst_coap_msg_ptr->coap_status = COAP_STATUS_PARSER_DUPLICATED_MSG;
-
-        /* Because duplicate message, return with coap_status set */
-        return returned_dst_coap_msg_ptr;
     }
 #endif
 

--- a/test/nsdl-c/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/nsdl-c/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -450,7 +450,6 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 1;
     struct coap_s * handle = sn_coap_protocol_init(myMalloc, myFree, null_tx_cb, NULL);
-
     sn_nsdl_addr_s* addr = (sn_nsdl_addr_s*)malloc(sizeof(sn_nsdl_addr_s));
     memset(addr, 0, sizeof(sn_nsdl_addr_s));
 
@@ -582,7 +581,7 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
     memset(list, 0, sizeof(sn_coap_options_list_s));
     sn_coap_parser_stub.expectedHeader->options_list_ptr = list;
     sn_coap_parser_stub.expectedHeader->options_list_ptr->block1 = 1;
-    sn_coap_parser_stub.expectedHeader->msg_id = 4;
+    sn_coap_parser_stub.expectedHeader->msg_id = 5;
     sn_coap_parser_stub.expectedHeader->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
     sn_coap_parser_stub.expectedHeader->msg_code = COAP_MSG_CODE_REQUEST_GET;
     payload = (uint8_t*)malloc(17);


### PR DESCRIPTION
RFC 7252 chapter 4.5 talks only duplication of Confirmable- and
Non-confirmable messages. Adding check for message type before
processing duplication store and check.

@anttiylitokola @yogpan01 @mikter - please review