### PR TITLE
Valgrind unittest fixes

### DIFF
--- a/test/nsdl-c/unittest/sn_coap_builder/libCoap_builder_test.cpp
+++ b/test/nsdl-c/unittest/sn_coap_builder/libCoap_builder_test.cpp
@@ -318,20 +318,23 @@ TEST(libCoap_builder, sn_coap_builder_calc_needed_packet_data_size)
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 16);
 
     //proxy uri tests (4)
-    header.options_list_ptr->proxy_uri_ptr = (uint8_t*)malloc(270);
+    header.options_list_ptr->proxy_uri_ptr = (uint8_t*)malloc(1800);
     header.options_list_ptr->proxy_uri_len = 1800;
     header.options_list_ptr->max_age = COAP_OPTION_MAX_AGE_DEFAULT;
     header.options_list_ptr->accept = COAP_CT_NONE;
 
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 0);
     header.options_list_ptr->proxy_uri_len = 6;
-    header.options_list_ptr->etag_ptr = (uint8_t*)malloc(6);
+    header.options_list_ptr->etag_ptr = (uint8_t*)malloc(4);
     header.options_list_ptr->etag_len = 0;
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 0);
 
     header.options_list_ptr->proxy_uri_len = 14;
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 0);
 
+    // init now the buffer up to 4 bytes, as it will be accessed
+    memset(header.options_list_ptr->etag_ptr, 0, 4);
+    
     header.options_list_ptr->proxy_uri_len = 281;
     header.options_list_ptr->block1 = COAP_OPTION_BLOCK_NONE;
     header.options_list_ptr->block2 = COAP_OPTION_BLOCK_NONE;
@@ -343,7 +346,7 @@ TEST(libCoap_builder, sn_coap_builder_calc_needed_packet_data_size)
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 0);
 
     header.options_list_ptr->uri_host_len = 4;
-    header.options_list_ptr->location_path_ptr = (uint8_t*)malloc(6);
+    header.options_list_ptr->location_path_ptr = (uint8_t*)calloc(270, 1);
     header.options_list_ptr->location_path_len = 270;
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 0);
 
@@ -357,7 +360,7 @@ TEST(libCoap_builder, sn_coap_builder_calc_needed_packet_data_size)
     header.options_list_ptr->uri_port = 6;
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 377);
 
-    header.options_list_ptr->location_query_ptr = (uint8_t*)malloc(6);
+    header.options_list_ptr->location_query_ptr = (uint8_t*)calloc(277, 1);
     header.options_list_ptr->location_query_len = 277;
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 0);
 
@@ -372,6 +375,8 @@ TEST(libCoap_builder, sn_coap_builder_calc_needed_packet_data_size)
     header.options_list_ptr->uri_query_len = 0;
     CHECK(sn_coap_builder_calc_needed_packet_data_size(&header) == 0);
 
+    // init the 4 bytes to something useful, leave rest uninitialized to let valgrind warn if builder is processing past buffer
+    memset(header.options_list_ptr->uri_query_ptr, 0, 4);
     header.options_list_ptr->uri_query_len = 4;
     header.options_list_ptr->block2 = -1;
     header.options_list_ptr->observe = 0xFFFFFF22;

--- a/test/nsdl-c/unittest/sn_coap_parser/test_sn_coap_parser.c
+++ b/test/nsdl-c/unittest/sn_coap_parser/test_sn_coap_parser.c
@@ -8,6 +8,7 @@
 #include "sn_coap_header.h"
 #include "sn_coap_header_internal.h"
 #include "sn_coap_protocol_internal.h"
+#include <assert.h>
 
 int retCounter = 0;
 
@@ -37,7 +38,9 @@ bool test_sn_coap_parser()
 
     retCounter = 0;
     bool ret = true;
-    uint8_t* ptr = (uint8_t*)malloc(20);
+    // use zero-initialized buffer for tests
+    uint8_t* ptr = (uint8_t*)calloc(20, 1);
+    assert(ptr);
     sn_coap_hdr_s * hdr = sn_coap_parser(NULL, 8, ptr, NULL);
     if( hdr != NULL ){
         free(hdr);

--- a/test/nsdl-c/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
+++ b/test/nsdl-c/unittest/sn_coap_protocol/libCoap_protocol_test.cpp
@@ -384,24 +384,25 @@ TEST(libCoap_protocol, sn_coap_protocol_build)
     hdr2->options_list_ptr->use_size1 = true;
     hdr2->options_list_ptr->size1 = 0xFFFF01;
 
-    hdr2->payload_ptr = (uint8_t*)malloc(3);
+    int buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    hdr2->payload_ptr = (uint8_t*)malloc(buff_len);
 
     for( int i=0; i < 8; i++ ){
         retCounter = 1 + i;
         sn_coap_builder_stub.expectedInt16 = 1;
-        hdr2->payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+        hdr2->payload_len = buff_len;
         int8_t rett = sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL);
         CHECK( -2 == rett );
     }
 
     retCounter = 11;
     sn_coap_builder_stub.expectedInt16 = 1;
-    hdr2->payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    hdr2->payload_len = buff_len;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL));
 
     retCounter = 19;
     sn_coap_builder_stub.expectedInt16 = 1;
-    hdr2->payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    hdr2->payload_len = buff_len;
     CHECK( 1 == sn_coap_protocol_build(handle, &addr, dst_packet_data_ptr, hdr2, NULL));
 
     free(hdr2->payload_ptr);
@@ -842,12 +843,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    int buff_size = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_size);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 16;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_size;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -890,13 +892,14 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 21;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    int buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block1 = -1;
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 17;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
 
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
@@ -937,7 +940,8 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = UINT16_MAX;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
 //    tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
 //    memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
 //    tmp_hdr.options_list_ptr->block2 = 1;
@@ -1095,12 +1099,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 16;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1144,13 +1149,14 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 21;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block1 = -1;
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 17;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
 
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
@@ -1196,14 +1202,15 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->use_size2 = true;
     tmp_hdr.options_list_ptr->size2 = 0xFF01;
     tmp_hdr.msg_id = 18;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1349,11 +1356,12 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
 
     tmp_hdr.msg_id = 20;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1424,12 +1432,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 41;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1471,12 +1480,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 42;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1518,12 +1528,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 43;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1564,12 +1575,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 44;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1609,12 +1621,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 45;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1655,12 +1668,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 46;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1705,12 +1719,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 47;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1757,12 +1772,13 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 1;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(tmp_hdr.options_list_ptr, 0, sizeof(sn_coap_options_list_s));
     tmp_hdr.options_list_ptr->block2 = 1;
     tmp_hdr.msg_id = 47;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1941,10 +1957,11 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.msg_id = 18;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -1980,10 +1997,11 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.msg_id = 18;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     tmp_hdr.uri_path_ptr = (uint8_t*)malloc(7);
     snprintf((char *)tmp_hdr.uri_path_ptr, 7, "13/0/1");
     tmp_hdr.uri_path_len = 7;
@@ -2024,10 +2042,11 @@ TEST(libCoap_protocol, sn_coap_protocol_parse)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    buff_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_len);
     tmp_hdr.msg_id = 18;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_len;
     tmp_hdr.uri_path_ptr = (uint8_t*)malloc(7);
     snprintf((char *)tmp_hdr.uri_path_ptr, 7, "13/0/1");
     tmp_hdr.uri_path_len = 7;
@@ -2069,10 +2088,11 @@ TEST(libCoap_protocol, sn_coap_protocol_exec)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    int buff_size = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buff_size);
     tmp_hdr.msg_id = 18;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buff_size;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);
@@ -2135,10 +2155,11 @@ TEST(libCoap_protocol, sn_coap_protocol_exec2)
 
     retCounter = 20;
     sn_coap_builder_stub.expectedInt16 = 5;
-    tmp_hdr.payload_ptr = (uint8_t*)malloc(3);
+    int buf_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_ptr = (uint8_t*)malloc(buf_len);
     tmp_hdr.msg_id = 18;
     tmp_hdr.msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
-    tmp_hdr.payload_len = SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE + 20;
+    tmp_hdr.payload_len = buf_len;
     sn_coap_protocol_build(handle, &tmp_addr, dst_packet_data_ptr, &tmp_hdr, NULL);
 
     free(tmp_hdr.options_list_ptr);

--- a/test/nsdl-c/unittest/sn_grs/test_sn_grs.c
+++ b/test/nsdl-c/unittest/sn_grs/test_sn_grs.c
@@ -646,10 +646,11 @@ bool test_sn_grs_process_coap()
     memset(hdr, 0, sizeof(sn_coap_hdr_s));
     hdr->msg_code = COAP_MSG_CODE_REQUEST_GET;
     hdr->msg_type = COAP_MSG_TYPE_RESET;
-    hdr->uri_path_ptr = (uint8_t*)malloc(2);
+    hdr->uri_path_ptr = (uint8_t*)calloc(2, 1);
     hdr->uri_path_len = 2;
     hdr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED;
-    hdr->payload_ptr = (uint8_t*)malloc(2);
+    hdr->payload_ptr = (uint8_t*)calloc(2, 1);
+    hdr->payload_len = 2;
 
     if( SN_NSDL_SUCCESS != sn_grs_process_coap(handle, hdr, addr) ){
         return false;
@@ -660,10 +661,11 @@ bool test_sn_grs_process_coap()
     memset(hdr, 0, sizeof(sn_coap_hdr_s));
     hdr->msg_code = COAP_MSG_CODE_REQUEST_POST;
     hdr->msg_type = COAP_MSG_TYPE_RESET;
-    hdr->uri_path_ptr = (uint8_t*)malloc(2);
+    hdr->uri_path_ptr = (uint8_t*)calloc(2, 1);
     hdr->uri_path_len = 2;
     hdr->coap_status = COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED;
     hdr->payload_ptr = (uint8_t*)malloc(2);
+    hdr->payload_len = 2;
 
     if( SN_NSDL_SUCCESS != sn_grs_process_coap(handle, hdr, addr) ){
         return false;

--- a/test/nsdl-c/unittest/sn_nsdl/test_sn_nsdl.c
+++ b/test/nsdl-c/unittest/sn_nsdl/test_sn_nsdl.c
@@ -279,6 +279,7 @@ bool test_sn_nsdl_register_endpoint()
     sn_grs_stub.expectedInfo->resource_parameters_ptr->interface_description_ptr[1] = '\0';
     sn_grs_stub.expectedInfo->resource_parameters_ptr->interface_description_len = 1;
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
+    sn_grs_stub.expectedInfo->resource_parameters_ptr->coap_content_type = 0; // XXX: why was this left uninitialized? what was point of this test?
 
     sn_grs_stub.expectedInfo->path = (uint8_t*)malloc(2);
     sn_grs_stub.expectedInfo->path[0] = 'a';
@@ -309,7 +310,7 @@ bool test_sn_nsdl_register_endpoint()
     sn_grs_stub.infoRetCounter = 1;
     sn_grs_stub.expectedInfo = (sn_nsdl_resource_info_s*)malloc(sizeof(sn_nsdl_resource_info_s));
     memset( sn_grs_stub.expectedInfo, 0, sizeof(sn_nsdl_resource_info_s));
-    sn_grs_stub.expectedInfo->resource_parameters_ptr = (sn_nsdl_resource_parameters_s*)malloc(sizeof(sn_nsdl_resource_parameters_s));
+    sn_grs_stub.expectedInfo->resource_parameters_ptr = (sn_nsdl_resource_parameters_s*)calloc(sizeof(sn_nsdl_resource_parameters_s), 1);
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
     sn_grs_stub.expectedInfo->publish_uri = 1;
     eptr->binding_and_mode = 0x06;
@@ -351,6 +352,7 @@ bool test_sn_nsdl_register_endpoint()
     sn_grs_stub.expectedInfo->resource_parameters_ptr->interface_description_ptr[1] = '\0';
     sn_grs_stub.expectedInfo->resource_parameters_ptr->interface_description_len = 1;
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
+    sn_grs_stub.expectedInfo->resource_parameters_ptr->coap_content_type = 0;
 
     sn_grs_stub.expectedInfo->path = (uint8_t*)malloc(2);
     sn_grs_stub.expectedInfo->path[0] = 'a';
@@ -617,6 +619,7 @@ bool test_sn_nsdl_register_endpoint()
     sn_grs_stub.expectedInfo->resource_parameters_ptr->interface_description_ptr[1] = '\0';
     sn_grs_stub.expectedInfo->resource_parameters_ptr->interface_description_len = 1;
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
+    sn_grs_stub.expectedInfo->resource_parameters_ptr->coap_content_type = 0;
     sn_grs_stub.expectedInfo->path = (uint8_t*)malloc(2);
     sn_grs_stub.expectedInfo->path[0] = 'a';
     sn_grs_stub.expectedInfo->path[1] = '\0';
@@ -830,7 +833,7 @@ bool test_sn_nsdl_update_registration()
     sn_grs_stub.infoRetCounter = 1;
     sn_grs_stub.expectedInfo = (sn_nsdl_resource_info_s*)malloc(sizeof(sn_nsdl_resource_info_s));
     memset( sn_grs_stub.expectedInfo, 0, sizeof(sn_nsdl_resource_info_s));
-    sn_grs_stub.expectedInfo->resource_parameters_ptr = (sn_nsdl_resource_parameters_s*)malloc(sizeof(sn_nsdl_resource_parameters_s));
+    sn_grs_stub.expectedInfo->resource_parameters_ptr = (sn_nsdl_resource_parameters_s*)calloc(sizeof(sn_nsdl_resource_parameters_s), 1);
     sn_grs_stub.expectedInfo->resource_parameters_ptr->observable = 1;
     sn_grs_stub.expectedInfo->publish_uri = 1;
     retCounter = 3;
@@ -1505,7 +1508,7 @@ bool test_sn_nsdl_process_coap()
     sn_coap_protocol_stub.expectedHeader->msg_code = COAP_MSG_CODE_RESPONSE_CREATED;
     sn_coap_protocol_stub.expectedHeader->options_list_ptr = (sn_coap_options_list_s*)malloc(sizeof(sn_coap_options_list_s));
     memset(sn_coap_protocol_stub.expectedHeader->options_list_ptr, 0, sizeof(sn_coap_options_list_s));
-    sn_coap_protocol_stub.expectedHeader->options_list_ptr->location_path_ptr = (uint8_t*)malloc(2);
+    sn_coap_protocol_stub.expectedHeader->options_list_ptr->location_path_ptr = (uint8_t*)calloc(2, 1);
     sn_coap_protocol_stub.expectedHeader->options_list_ptr->location_path_len = 2;
     handle->register_msg_id = 5;
 
@@ -2650,35 +2653,41 @@ bool test_set_NSP_address()
     handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = (uint8_t*)malloc(2);
     memset( handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, 0, 2 );
 
-    uint8_t* addr = (uint8_t*)malloc(2);
-    memset(addr, 0, 2);
+    // Note: the set_NSP_address() will read 4 bytes of source address
+    uint8_t* addr4 = (uint8_t*)calloc(4, 1);
 
-    if( SN_NSDL_FAILURE != set_NSP_address(handle, addr, 0, SN_NSDL_ADDRESS_TYPE_IPV4) ){
+    if( SN_NSDL_FAILURE != set_NSP_address(handle, addr4, 0, SN_NSDL_ADDRESS_TYPE_IPV4) ){
         return false;
     }
     handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = NULL;
 
     retCounter = 1;
-    if( SN_NSDL_SUCCESS != set_NSP_address(handle, addr, 0, SN_NSDL_ADDRESS_TYPE_IPV4) ){
+    if( SN_NSDL_SUCCESS != set_NSP_address(handle, addr4, 0, SN_NSDL_ADDRESS_TYPE_IPV4) ){
         return false;
     }
     free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
     handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = NULL;
 
-    if( SN_NSDL_FAILURE != set_NSP_address(handle, addr, 0, SN_NSDL_ADDRESS_TYPE_IPV6) ){
+    // Note: the set_NSP_address() will read 16 bytes of source address
+    uint8_t* addr6 = (uint8_t*)calloc(16, 1);
+
+    if( SN_NSDL_FAILURE != set_NSP_address(handle, addr6, 0, SN_NSDL_ADDRESS_TYPE_IPV6) ){
         return false;
     }
+
 
     handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = NULL;
     handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = (uint8_t*)malloc(2);
+    handle->nsp_address_ptr->omalw_address_ptr->addr_len = 2;
     memset( handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, 0, 2 );
 
     retCounter = 1;
-    if( SN_NSDL_SUCCESS != set_NSP_address(handle, addr, 0, SN_NSDL_ADDRESS_TYPE_IPV6) ){
+    if( SN_NSDL_SUCCESS != set_NSP_address(handle, addr6, 0, SN_NSDL_ADDRESS_TYPE_IPV6) ){
         return false;
     }
 
-    free(addr);
+    free(addr4);
+    free(addr6);
     sn_nsdl_destroy(handle);
     return true;
 }
@@ -2880,7 +2889,7 @@ bool test_sn_nsdl_release_allocated_coap_msg_mem()
     memset(sn_grs_stub.expectedGrs,0, sizeof(struct grs_s));
     struct nsdl_s* handle = sn_nsdl_init(&nsdl_tx_callback, &nsdl_rx_callback, &myMalloc, &myFree);
 
-    sn_coap_hdr_s* list = (sn_coap_hdr_s*)malloc(sizeof(sn_coap_hdr_s));
+    sn_coap_hdr_s* list = (sn_coap_hdr_s*)calloc(sizeof(sn_coap_hdr_s), 1);
 
     sn_nsdl_release_allocated_coap_msg_mem(handle, list); //mem leak or pass
 


### PR DESCRIPTION
Starting point:
./run_unit_tests_with_valgrind.sh 2>&1 >/dev/null |grep ERROR 
==20487== ERROR SUMMARY: 10 errors from 10 contexts (suppressed: 0 from 0)
==20488== ERROR SUMMARY: 1976 errors from 16 contexts (suppressed: 0 from 0)
==20489== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==20490== ERROR SUMMARY: 297 errors from 66 contexts (suppressed: 0 from 0)
==20491== ERROR SUMMARY: 23 errors from 17 contexts (suppressed: 0 from 0)
==20492== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
