### PR TITLE
Disable message duplication

### DIFF
--- a/source/libCoap/src/include/sn_coap_protocol_internal.h
+++ b/source/libCoap/src/include/sn_coap_protocol_internal.h
@@ -80,7 +80,7 @@ struct sn_coap_hdr_;
 
 // Keep the old flag to maintain backward compatibility
 #ifndef SN_COAP_DUPLICATION_MAX_MSGS_COUNT
-#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              1
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              0
 #endif
 
 #ifdef YOTTA_CFG_COAP_DUPLICATION_MAX_MSGS_COUNT


### PR DESCRIPTION
Message duplication is currently missing some features and it doesn't work reliable yet. Can be enabled again once "IOTCLT-1038
CoAP duplicate message detection missing features" is implemented.