### PR TITLE
Revert 3b172c6 Notify client when observation is cancelled with RESET…

### DIFF
--- a/nsdl-c/sn_nsdl_lib.h
+++ b/nsdl-c/sn_nsdl_lib.h
@@ -312,39 +312,6 @@ extern uint16_t sn_nsdl_send_observation_notification(struct nsdl_s *handle, uin
         sn_coap_content_format_e content_format);
 
 /**
- * \fn extern uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
- *                                                  uint8_t *payload_ptr, uint16_t payload_len,
- *                                                  sn_coap_observe_e observe,
- *                                                  sn_coap_msg_type_e message_type, uint8_t content_type,
- *                                                  uint8_t *uri_path_ptr,
- *                                                  uint16_t uri_path_len)
- *
- *
- * \brief Sends observation message to mbed Device Server with uri path
- *
- * \param   *handle         Pointer to nsdl-library handle
- * \param   *token_ptr      Pointer to token to be used
- * \param   token_len       Token length
- * \param   *payload_ptr    Pointer to payload to be sent
- * \param   payload_len     Payload length
- * \param   observe         Observe option value to be sent
- * \param   message_type    Observation message type (confirmable or non-confirmable)
- * \param   content_type    Observation message payload contetnt type
- * \param   uri_path_ptr    Pointer to uri path to be sent
- * \param   uri_path_len    Uri path len
- *
- * \return  !0  Success, observation messages message ID
- * \return  0   Failure
- */
-extern uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
-        uint8_t *payload_ptr, uint16_t payload_len,
-        sn_coap_observe_e observe,
-        sn_coap_msg_type_e message_type,
-        uint8_t content_type,
-        uint8_t *uri_path_ptr,
-        uint16_t uri_path_len);
-
-/**
  * \fn extern uint32_t sn_nsdl_get_version(void)
  *
  * \brief Version query function.

--- a/source/libCoap/src/include/sn_coap_header_internal.h
+++ b/source/libCoap/src/include/sn_coap_header_internal.h
@@ -64,8 +64,6 @@ typedef struct sn_nsdl_transmit_ {
 
     uint16_t                packet_len;
     uint8_t                *packet_ptr;
-    uint8_t                *uri_path_ptr;
-    uint8_t                uri_path_len;
 } sn_nsdl_transmit_s;
 
 /* * * * * * * * * * * * * * * * * * * * * * */

--- a/source/libCoap/src/sn_coap_builder.c
+++ b/source/libCoap/src/sn_coap_builder.c
@@ -175,21 +175,16 @@ uint16_t sn_coap_builder_calc_needed_packet_data_size_2(sn_coap_hdr_s *src_coap_
             returned_byte_count += src_coap_msg_ptr->token_len;
         }
         /* URI PATH - Repeatable option. Length of one option is 0-255 */
-        /* Do not add uri-path for notification message.
-         * Uri-path is needed for cancelling observation with RESET message */
-        if (!src_coap_msg_ptr->options_list_ptr ||
-                (src_coap_msg_ptr->options_list_ptr &&
-                 COAP_OBSERVE_NONE == src_coap_msg_ptr->options_list_ptr->observe)) {
-            if (src_coap_msg_ptr->uri_path_ptr != NULL) {
-                repeatable_option_size = sn_coap_builder_options_calc_option_size(src_coap_msg_ptr->uri_path_len,
-                                         src_coap_msg_ptr->uri_path_ptr, COAP_OPTION_URI_PATH);
-                if (repeatable_option_size) {
-                    returned_byte_count += repeatable_option_size;
-                } else {
-                    return 0;
-                }
+        if (src_coap_msg_ptr->uri_path_ptr != NULL) {
+            repeatable_option_size = sn_coap_builder_options_calc_option_size(src_coap_msg_ptr->uri_path_len,
+                                     src_coap_msg_ptr->uri_path_ptr, COAP_OPTION_URI_PATH);
+            if (repeatable_option_size) {
+                returned_byte_count += repeatable_option_size;
+            } else {
+                return 0;
             }
         }
+
         uint16_t tempInt = 0;
         /* CONTENT FORMAT - An integer option, up to 2 bytes */
         if (src_coap_msg_ptr->content_format != COAP_CT_NONE) {
@@ -575,13 +570,8 @@ static int8_t sn_coap_builder_options_build(uint8_t **dst_packet_data_pptr, sn_c
                      &src_coap_msg_ptr->options_list_ptr->location_path_len, COAP_OPTION_LOCATION_PATH, &previous_option_number);
     }
     /* * * * Build Uri-Path option * * * */
-    /* Do not add uri-path for notification message.
-     * Uri-path is needed for cancelling observation with RESET message */
-    if (!src_coap_msg_ptr->options_list_ptr ||
-            (src_coap_msg_ptr->options_list_ptr &&
-             COAP_OBSERVE_NONE == src_coap_msg_ptr->options_list_ptr->observe))
-        sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, &src_coap_msg_ptr->uri_path_ptr,
-                 &src_coap_msg_ptr->uri_path_len, COAP_OPTION_URI_PATH, &previous_option_number);
+    sn_coap_builder_options_build_add_multiple_option(dst_packet_data_pptr, &src_coap_msg_ptr->uri_path_ptr,
+             &src_coap_msg_ptr->uri_path_len, COAP_OPTION_URI_PATH, &previous_option_number);
 
     /* * * * Build Content-Type option * * * */
     if (src_coap_msg_ptr->content_format != COAP_CT_NONE) {

--- a/source/libCoap/src/sn_coap_protocol.c
+++ b/source/libCoap/src/sn_coap_protocol.c
@@ -68,7 +68,7 @@ static int8_t                sn_coap_convert_block_size(uint16_t block_size);
 static sn_coap_hdr_s        *sn_coap_protocol_copy_header(struct coap_s *handle, sn_coap_hdr_s *source_header_ptr);
 #endif
 #if ENABLE_RESENDINGS
-static void                  sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t send_packet_data_len, uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param, uint8_t *uri_path_ptr, uint8_t uri_path_len);
+static void                  sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t send_packet_data_len, uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param);
 static sn_nsdl_transmit_s   *sn_coap_protocol_linked_list_send_msg_search(struct coap_s *handle,sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id);
 static void                  sn_coap_protocol_linked_list_send_msg_remove(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id);
 static coap_send_msg_s      *sn_coap_protocol_allocate_mem_for_msg(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t packet_data_len);
@@ -314,10 +314,6 @@ void sn_coap_protocol_clear_retransmission_buffer(struct coap_s *handle)
                 handle->sn_coap_protocol_free(tmp->send_msg_ptr->packet_ptr);
                 tmp->send_msg_ptr->packet_ptr = 0;
             }
-            if (tmp->send_msg_ptr->uri_path_ptr) {
-                handle->sn_coap_protocol_free(tmp->send_msg_ptr->uri_path_ptr);
-                tmp->send_msg_ptr->uri_path_ptr = 0;
-            }
             handle->sn_coap_protocol_free(tmp->send_msg_ptr);
             tmp->send_msg_ptr = 0;
         }
@@ -448,7 +444,7 @@ int16_t sn_coap_protocol_build(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_p
         /* Store message to Linked list for resending purposes */
         sn_coap_protocol_linked_list_send_msg_store(handle, dst_addr_ptr, byte_count_built, dst_packet_data_ptr,
                 handle->system_time + (uint32_t)(handle->sn_coap_resending_intervall * RESPONSE_RANDOM_FACTOR),
-                param, src_coap_msg_ptr->uri_path_ptr, src_coap_msg_ptr->uri_path_len);
+                param);
     }
 
 #endif /* ENABLE_RESENDINGS */
@@ -703,15 +699,6 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
             removed_msg_ptr = sn_coap_protocol_linked_list_send_msg_search(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id);
 
             if (removed_msg_ptr != NULL) {
-                if (returned_dst_coap_msg_ptr->msg_type == COAP_MSG_TYPE_RESET) {
-                    if(removed_msg_ptr->uri_path_len) {
-                        returned_dst_coap_msg_ptr->uri_path_ptr = handle->sn_coap_protocol_malloc(removed_msg_ptr->uri_path_len);
-                        if (returned_dst_coap_msg_ptr->uri_path_ptr != NULL) {
-                            memcpy(returned_dst_coap_msg_ptr->uri_path_ptr, removed_msg_ptr->uri_path_ptr, removed_msg_ptr->uri_path_len);
-                            returned_dst_coap_msg_ptr->uri_path_len = removed_msg_ptr->uri_path_len;
-                        }
-                    }
-                }
                 /* Remove resending message from active message resending Linked list */
                 sn_coap_protocol_linked_list_send_msg_remove(handle, src_addr_ptr, returned_dst_coap_msg_ptr->msg_id);
             }
@@ -814,7 +801,7 @@ int8_t sn_coap_protocol_exec(struct coap_s *handle, uint32_t current_time)
  *****************************************************************************/
 
 static void sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, sn_nsdl_addr_s *dst_addr_ptr, uint16_t send_packet_data_len,
-        uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param, uint8_t *uri_path_ptr, uint8_t uri_path_len)
+        uint8_t *send_packet_data_ptr, uint32_t sending_time, void *param)
 {
 
     coap_send_msg_s *stored_msg_ptr              = NULL;
@@ -861,16 +848,6 @@ static void sn_coap_protocol_linked_list_send_msg_store(struct coap_s *handle, s
 
     stored_msg_ptr->coap = handle;
     stored_msg_ptr->param = param;
-
-    if (uri_path_len) {
-        stored_msg_ptr->send_msg_ptr->uri_path_ptr = handle->sn_coap_protocol_malloc(uri_path_len);
-        if (stored_msg_ptr->send_msg_ptr->uri_path_ptr == NULL){
-            return;
-        }
-        stored_msg_ptr->send_msg_ptr->uri_path_len = uri_path_len;
-        memcpy(stored_msg_ptr->send_msg_ptr->uri_path_ptr, uri_path_ptr, uri_path_len);
-    }
-
 
     /* Storing Resending message to Linked list */
     ns_list_add_to_end(&handle->linked_list_resent_msgs, stored_msg_ptr);
@@ -1448,11 +1425,6 @@ static void sn_coap_protocol_release_allocated_send_msg_mem(struct coap_s *handl
                 freed_send_msg_ptr->send_msg_ptr->packet_ptr = 0;
             }
 
-            if (freed_send_msg_ptr->send_msg_ptr->uri_path_ptr != NULL) {
-                handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr->uri_path_ptr);
-                freed_send_msg_ptr->send_msg_ptr->uri_path_ptr = 0;
-            }
-
             handle->sn_coap_protocol_free(freed_send_msg_ptr->send_msg_ptr);
             freed_send_msg_ptr->send_msg_ptr = 0;
         }
@@ -1878,7 +1850,7 @@ static sn_coap_hdr_s *sn_coap_handle_blockwise_message(struct coap_s *handle, sn
                 sn_coap_protocol_linked_list_send_msg_store(handle, src_addr_ptr,
                         dst_packed_data_needed_mem,
                         dst_ack_packet_data_ptr,
-                        handle->system_time + (uint32_t)(handle->sn_coap_resending_intervall * RESPONSE_RANDOM_FACTOR), param, NULL, 0);
+                        handle->system_time + (uint32_t)(handle->sn_coap_resending_intervall * RESPONSE_RANDOM_FACTOR), param);
 #endif
                 handle->sn_coap_protocol_free(dst_ack_packet_data_ptr);
                 dst_ack_packet_data_ptr = 0;


### PR DESCRIPTION
… message

Reset message is now passed into application and mbed-client will use the token to match request to right object.

With this change we get rid of unnecessary uri_path() API in mbed-client side.