### PR TITLE
nsdl: add sn_grs_pop_resource function

### DIFF
--- a/nsdl-c/sn_nsdl_lib.h
+++ b/nsdl-c/sn_nsdl_lib.h
@@ -400,14 +400,15 @@ extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_dynamic_res
 #endif
 
 /**
- * \fn  extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, const sn_nsdl_resource_parameters_s *res);
+ * \fn  extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, const sn_nsdl_dynamic_resource_parameters_s *res);
  *
  * \brief Resource putting function.
  *
  * Used to put a static or dynamic CoAP resource without creating copy of it.
  * NOTE: Remember that only resource will be owned, not data that it contains
+ * NOTE: The resource may be removed from list by sn_nsdl_pop_resource().
  *
- * \param   *res    Pointer to a structure of type sn_nsdl_resource_info_t that contains the information
+ * \param   *res    Pointer to a structure of type sn_nsdl_dynamic_resource_parameters_s that contains the information
  *     about the resource.
  *
  * \return  0   Success
@@ -417,6 +418,23 @@ extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_dynamic_res
  * \return  -4  List adding failure
  */
 extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
+
+/**
+ * \fn  extern int8_t sn_nsdl_pop_resource(struct nsdl_s *handle, const sn_nsdl_dynamic_resource_parameters_s *res);
+ *
+ * \brief Resource popping function.
+ *
+ * Used to remove a static or dynamic CoAP resource from lists without deleting it.
+ * NOTE: This function is a counterpart of sn_nsdl_put_resource().
+ *
+ * \param   *res    Pointer to a structure of type sn_nsdl_dynamic_resource_parameters_s that contains the information
+ *     about the resource.
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ * \return  -3  Invalid path
+ */
+extern int8_t sn_nsdl_pop_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
 
 /**
  * \fn extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint8_t pathlen, uint8_t *path)

--- a/source/libNsdl/src/include/sn_grs.h
+++ b/source/libNsdl/src/include/sn_grs.h
@@ -132,6 +132,7 @@ extern int8_t                                   sn_grs_send_coap_message(struct 
                                                                          sn_nsdl_addr_s *address_ptr,
                                                                          sn_coap_hdr_s *coap_hdr_ptr);
 extern int8_t                                   sn_grs_put_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
+extern int8_t                                   sn_grs_pop_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
 extern int8_t                                   sn_grs_delete_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path);
 extern void                                     sn_grs_mark_resources_as_registered(struct nsdl_s *handle);
 #ifndef MEMORY_OPTIMIZED_API

--- a/source/libNsdl/src/sn_grs.c
+++ b/source/libNsdl/src/sn_grs.c
@@ -510,6 +510,29 @@ int8_t sn_grs_put_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parame
     return SN_NSDL_SUCCESS;
 }
 
+int8_t sn_grs_pop_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
+{
+    if (!res || !handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Check path validity */
+    if (!res->static_resource_parameters->pathlen || !res->static_resource_parameters->path) {
+        return SN_GRS_INVALID_PATH;
+    }
+
+    /* Check if resource exists on list. */
+    if (sn_grs_search_resource(handle,
+                               res->static_resource_parameters->pathlen,
+                               res->static_resource_parameters->path, SN_GRS_SEARCH_METHOD) == (sn_nsdl_dynamic_resource_parameters_s *)NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    ns_list_remove(&handle->resource_root_list, res);
+    --handle->resource_root_count;
+
+    return SN_NSDL_SUCCESS;
+}
 
 /**
  * \fn  extern int8_t sn_grs_process_coap(uint8_t *packet, uint16_t *packet_len, sn_nsdl_addr_s *src)

--- a/source/libNsdl/src/sn_nsdl.c
+++ b/source/libNsdl/src/sn_nsdl.c
@@ -1624,6 +1624,15 @@ extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resour
     return sn_grs_put_resource(handle->grs, res);
 }
 
+extern int8_t sn_nsdl_pop_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
+{
+    if (!handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return sn_grs_pop_resource(handle->grs, res);
+}
+
 extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
 {
     /* Check parameters */

--- a/test/nsdl-c/unittest/sn_nsdl/test_sn_nsdl.c
+++ b/test/nsdl-c/unittest/sn_nsdl/test_sn_nsdl.c
@@ -2623,6 +2623,24 @@ bool test_sn_nsdl_put_resource()
         return false;
     }
 
+    /* Add real data and pop it back too. */
+    sn_nsdl_static_resource_parameters_s static_res = {
+        .path = "hello",
+        .pathlen = 5
+    };
+    
+    sn_nsdl_dynamic_resource_parameters_s dyn_res = {
+        .static_resource_parameters = &static_res
+    };
+
+    if( 0 != sn_nsdl_put_resource(handle, &dyn_res) ){
+        return false;
+    }
+
+    if( 0 != sn_nsdl_pop_resource(handle, &dyn_res) ){
+        return false;
+    }
+
     sn_nsdl_destroy(handle);
     return true;
 }

--- a/test/nsdl-c/unittest/stubs/sn_grs_stub.c
+++ b/test/nsdl-c/unittest/stubs/sn_grs_stub.c
@@ -144,6 +144,15 @@ int8_t sn_grs_put_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parame
     return sn_grs_stub.expectedInt8;
 }
 
+int8_t sn_grs_pop_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
+{
+    if( sn_grs_stub.int8SuccessCounter > 0 ){
+        sn_grs_stub.int8SuccessCounter++;
+        return SN_NSDL_SUCCESS;
+    }
+    return sn_grs_stub.expectedInt8;
+}
+
 extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coap_packet_ptr, sn_nsdl_addr_s *src_addr_ptr)
 {
     return sn_grs_stub.expectedInt8;


### PR DESCRIPTION
The sn_grs_put_resource() needs a counterpart for removing
the structure from the list. This makes it possible to manage
the lifetime of nsdl structures from client code.