### PR TITLE
Mem opt part 2

### DIFF
--- a/nsdl-c/sn_nsdl_lib.h
+++ b/nsdl-c/sn_nsdl_lib.h
@@ -25,6 +25,12 @@
 #ifndef SN_NSDL_LIB_H_
 #define SN_NSDL_LIB_H_
 
+#ifdef MBED_CLIENT_C_NEW_API
+
+#include "nsdl-c/sn_nsdl_lib2.h"
+
+#else
+
 #include "ns_list.h"
 
 #ifdef __cplusplus
@@ -755,5 +761,8 @@ extern void *sn_nsdl_get_context(const struct nsdl_s * const handle);
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* MBED_CLIENT_C_NEW_API */
+
 
 #endif /* SN_NSDL_LIB_H_ */

--- a/nsdl-c/sn_nsdl_lib2.h
+++ b/nsdl-c/sn_nsdl_lib2.h
@@ -22,8 +22,10 @@
 *
 */
 
-#ifndef SN_NSDL_LIB_H_
-#define SN_NSDL_LIB_H_
+#ifndef SN_NSDL_LIB_2_H_
+#define SN_NSDL_LIB_2_H_
+
+#ifdef MBED_CLIENT_C_NEW_API
 
 #include "mbed-client-libservice/ns_list.h"
 
@@ -660,5 +662,5 @@ extern void *sn_nsdl_get_context(const struct nsdl_s * const handle);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* SN_NSDL_LIB_H_ */
+#endif /* MBED_CLIENT_C_NEW_API */
+#endif /* SN_NSDL_LIB_2_H_ */

--- a/nsdl-c/sn_nsdl_lib2.h
+++ b/nsdl-c/sn_nsdl_lib2.h
@@ -1,0 +1,759 @@
+/*
+ * Copyright (c) 2011-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+* \file sn_nsdl_lib.h
+*
+* \brief NanoService Devices Library header file
+*
+*
+*/
+
+#ifndef SN_NSDL_LIB_H_
+#define SN_NSDL_LIB_H_
+
+#include "ns_list.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SN_NSDL_ENDPOINT_NOT_REGISTERED  0
+#define SN_NSDL_ENDPOINT_IS_REGISTERED   1
+
+/* Handle structure */
+struct nsdl_s;
+
+/**
+ * \brief Received device server security
+ */
+typedef enum omalw_server_security_ {
+    SEC_NOT_SET = -1,
+    PSK = 0,
+    RPK = 1,
+    CERTIFICATE = 2,
+    NO_SEC = 3
+} omalw_server_security_t;
+
+/**
+ * \brief Endpoint binding and mode
+ */
+typedef enum sn_nsdl_oma_binding_and_mode_ {
+    BINDING_MODE_NOT_SET = 0,
+    BINDING_MODE_U = 0x01,
+    BINDING_MODE_Q = 0x02,
+    BINDING_MODE_S = 0x04
+} sn_nsdl_oma_binding_and_mode_t;
+
+/**
+ * \brief Endpoint registration mode.
+ *      If REGISTER_WITH_RESOURCES, endpoint sends list of all resources during registration.
+ *      If REGISTER_WITH_TEMPLATE, endpoint sends registration without resource list. Device server must have
+ *      correctly configured template.
+ */
+typedef enum sn_nsdl_registration_mode_ {
+    REGISTER_WITH_RESOURCES = 0,
+    REGISTER_WITH_TEMPLATE
+} sn_nsdl_registration_mode_t;
+
+
+typedef struct omalw_certificate_list_ {
+    uint8_t  certificate_chain_len;
+    uint16_t own_private_key_len;
+    uint16_t certificate_len[2];
+    uint8_t  *certificate_ptr[2];
+    uint8_t  *own_private_key_ptr;
+} omalw_certificate_list_t;
+
+/**
+ * \brief Endpoint registration parameters
+ */
+typedef struct sn_nsdl_ep_parameters_ {
+    uint8_t     endpoint_name_len;
+    uint8_t     domain_name_len;
+    uint8_t     type_len;
+    uint8_t     lifetime_len;
+    uint8_t     location_len;
+
+    sn_nsdl_registration_mode_t ds_register_mode;       /**< Defines registration mode */
+    sn_nsdl_oma_binding_and_mode_t binding_and_mode;    /**< Defines endpoints binding and mode */
+
+    uint8_t     *endpoint_name_ptr;                     /**< Endpoint name */
+    uint8_t     *domain_name_ptr;                       /**< Domain to register. If null, NSP uses default domain */
+    uint8_t     *type_ptr;                              /**< Endpoint type */
+    uint8_t     *lifetime_ptr;                          /**< Endpoint lifetime in seconds. eg. "1200" = 1200 seconds */
+    uint8_t     *location_ptr;                          /**< Endpoint location in server, optional parameter,default is NULL */
+} sn_nsdl_ep_parameters_s;
+
+/**
+ * \brief For internal use
+ */
+typedef struct sn_nsdl_sent_messages_ {
+    uint8_t     message_type;
+    uint16_t    msg_id_number;
+    ns_list_link_t  link;
+} sn_nsdl_sent_messages_s;
+
+/**
+ * \brief Includes resource path
+ */
+typedef struct sn_grs_resource_ {
+    uint8_t pathlen;
+    uint8_t *path;
+} sn_grs_resource_s;
+
+/**
+ * \brief Table of created resources
+ */
+typedef struct sn_grs_resource_list_ {
+    uint8_t res_count;                  /**< Number of resources */
+    sn_grs_resource_s *res;
+} sn_grs_resource_list_s;
+
+/**
+ * \brief Resource access rights
+ */
+typedef enum sn_grs_resource_acl_ {
+    SN_GRS_GET_ALLOWED  = 0x01 ,
+    SN_GRS_PUT_ALLOWED  = 0x02,
+    SN_GRS_POST_ALLOWED = 0x04,
+    SN_GRS_DELETE_ALLOWED   = 0x08
+} sn_grs_resource_acl_e;
+
+
+typedef enum sn_nsdl_oma_device_error_ {
+    NO_ERROR = 0,
+    LOW_BATTERY_POWER = 1,
+    EXTERNAL_POWER_SUPPLY_OFF = 2,
+    GPS_MODULE_FAILURE = 3,
+    LOW_RECEIVED_SIGNAL_STRENGTH = 4,
+    OUT_OF_MEMORY = 5,
+    SMS_FAILURE = 6,
+    IP_CONN_FAILURE = 7,
+    PERIPHERAL_MALFUNCTION = 8
+} sn_nsdl_oma_device_error_t;
+
+/**
+ * \brief Defines the resource mode
+ */
+typedef enum sn_nsdl_resource_mode_ {
+    SN_GRS_STATIC = 0,                  /**< Static resources have some value that doesn't change */
+    SN_GRS_DYNAMIC,                     /**< Dynamic resources are handled in application. Therefore one must give function callback pointer to them */
+    SN_GRS_DIRECTORY                    /**< Directory resources are unused and unsupported */
+} sn_nsdl_resource_mode_e;
+
+/**
+ * \brief Resource registration parameters
+ */
+typedef struct sn_nsdl_resource_parameters_ {
+    unsigned int     observable:2;
+    unsigned int     registered:2;
+
+    uint16_t    resource_type_len;
+    uint16_t    interface_description_len;
+
+    uint16_t    coap_content_type;
+//    uint8_t     mime_content_type;
+
+    uint8_t     *resource_type_ptr;
+    uint8_t     *interface_description_ptr;
+
+} sn_nsdl_resource_parameters_s;
+
+/**
+ * \brief Defines parameters for the resource.
+ */
+typedef struct sn_nsdl_resource_info_ {
+
+    unsigned int                    mode:2;                     /**< STATIC etc.. */
+
+    unsigned int                    access:4;
+
+    bool                            publish_uri:1;
+
+    bool                            is_put:1; //if true, pointers are assumed to be consts (never freed). Note: resource_parameters_ptr is always freed!
+
+    uint8_t                         external_memory_block;
+
+    uint16_t                        pathlen;                    /**< Address */
+
+    uint16_t                        resourcelen;                /**< 0 if dynamic resource, resource information in static resource */
+
+    sn_nsdl_resource_parameters_s   *resource_parameters_ptr;
+
+    uint8_t (*sn_grs_dyn_res_callback)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *, sn_nsdl_capab_e);
+
+    uint8_t                         *path;
+
+    uint8_t                         *resource;                  /**< NULL if dynamic resource */
+
+    ns_list_link_t                  link;
+} sn_nsdl_resource_info_s;
+
+/**
+ * \brief Defines OMA device object parameters.
+ */
+typedef struct sn_nsdl_oma_device_ {
+    sn_nsdl_oma_device_error_t error_code;                                                                          /**< Error code. Mandatory. Can be more than one */
+    uint8_t (*sn_oma_device_boot_callback)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *, sn_nsdl_capab_e);    /**< Device boot callback function. If defined, this is called when reset request is received */
+
+} sn_nsdl_oma_device_t;
+
+/**
+ * \brief Defines OMAlw server information
+ */
+typedef struct sn_nsdl_oma_server_info_ {
+    sn_nsdl_addr_s *omalw_address_ptr;
+    omalw_server_security_t omalw_server_security;
+
+} sn_nsdl_oma_server_info_t;
+
+/**
+ * \brief Defines endpoint parameters to OMA bootstrap.
+ */
+typedef struct sn_nsdl_bs_ep_info_ {
+    void (*oma_bs_status_cb)(sn_nsdl_oma_server_info_t *);  /**< Callback for OMA bootstrap status */
+
+    void (*oma_bs_status_cb_handle)(sn_nsdl_oma_server_info_t *,
+                                    struct nsdl_s *);  /**< Callback for OMA bootstrap status with nsdl handle */
+
+    sn_nsdl_oma_device_t *device_object;                    /**< OMA LWM2M mandatory device resources */
+} sn_nsdl_bs_ep_info_t;
+
+
+
+
+/**
+ * \fn struct nsdl_s *sn_nsdl_init  (uint8_t (*sn_nsdl_tx_cb)(sn_nsdl_capab_e , uint8_t *, uint16_t, sn_nsdl_addr_s *),
+ *                          uint8_t (*sn_nsdl_rx_cb)(sn_coap_hdr_s *, sn_nsdl_addr_s *),
+ *                          sn_nsdl_mem_s *sn_memory)
+ *
+ * \brief Initialization function for NSDL library. Initializes NSDL, GRS, HTTP and CoAP.
+ *
+ * \param *sn_nsdl_tx_callback  A callback function for sending messages.
+ *
+ * \param *sn_nsdl_rx_callback  A callback function for parsed messages. If received message is not CoAP protocol message (eg. ACK), message for GRS (GET, PUT, POST, DELETE) or
+ *                              reply for some DS messages (register message etc.), rx callback will be called.
+ *
+ * \param *sn_memory            Memory structure which includes function pointers to the allocation and free functions.
+ *
+ * \return  pointer to created handle structure. NULL if failed
+ */
+struct nsdl_s *sn_nsdl_init(uint8_t (*sn_nsdl_tx_cb)(struct nsdl_s *, sn_nsdl_capab_e , uint8_t *, uint16_t, sn_nsdl_addr_s *),
+                            uint8_t (*sn_nsdl_rx_cb)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *),
+                            void *(*sn_nsdl_alloc)(uint16_t), void (*sn_nsdl_free)(void *));
+
+/**
+ * \fn extern uint16_t sn_nsdl_register_endpoint(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *endpoint_info_ptr);
+ *
+ * \brief Registers endpoint to mbed Device Server.
+ * \param *handle               Pointer to nsdl-library handle
+ * \param *endpoint_info_ptr    Contains endpoint information.
+ *
+ * \return registration message ID, 0 if failed
+ */
+extern uint16_t sn_nsdl_register_endpoint(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *endpoint_info_ptr);
+
+/**
+ * \fn extern uint16_t sn_nsdl_unregister_endpoint(struct nsdl_s *handle)
+ *
+ * \brief Sends unregister-message to mbed Device Server.
+ *
+ * \param *handle               Pointer to nsdl-library handle
+ *
+ * \return  unregistration message ID, 0 if failed
+ */
+extern uint16_t sn_nsdl_unregister_endpoint(struct nsdl_s *handle);
+
+/**
+ * \fn extern uint16_t sn_nsdl_update_registration(struct nsdl_s *handle, uint8_t *lt_ptr, uint8_t lt_len);
+ *
+ * \brief Update the registration with mbed Device Server.
+ *
+ * \param *handle   Pointer to nsdl-library handle
+ * \param *lt_ptr   Pointer to lifetime value string in ascii form, eg. "1200"
+ * \param lt_len    Length of the lifetime string
+ *
+ * \return  registration update message ID, 0 if failed
+ */
+extern uint16_t sn_nsdl_update_registration(struct nsdl_s *handle, uint8_t *lt_ptr, uint8_t lt_len);
+
+/**
+ * \fn extern int8_t sn_nsdl_set_endpoint_location(struct nsdl_s *handle, uint8_t *location_ptr, uint8_t location_len);
+ *
+ * \brief Sets the location receievd from Device Server.
+ *
+ * \param *handle   Pointer to nsdl-library handle
+ * \param *lt_ptr   Pointer to location value string , eg. "s322j4k"
+ * \param lt_len    Length of the location string
+ *
+ * \return  success, 0 if failed -1
+ */
+extern int8_t sn_nsdl_set_endpoint_location(struct nsdl_s *handle, uint8_t *location_ptr, uint8_t location_len);
+
+
+/**
+ * \fn extern int8_t sn_nsdl_is_ep_registered(struct nsdl_s *handle)
+ *
+ * \brief Checks if endpoint is registered.
+ *
+ * \param *handle   Pointer to nsdl-library handle
+ *
+ * \return 1 Endpoint registration is done successfully
+ * \return 0 Endpoint is not registered
+ */
+extern int8_t sn_nsdl_is_ep_registered(struct nsdl_s *handle);
+
+/**
+ * \fn extern void sn_nsdl_nsp_lost(struct nsdl_s *handle);
+ *
+ * \brief A function to inform mbed Device C client library if application detects a fault in mbed Device Server registration.
+ *
+ * \param *handle   Pointer to nsdl-library handle
+ *
+ * After calling this function sn_nsdl_is_ep_registered() will return "not registered".
+ */
+extern void sn_nsdl_nsp_lost(struct nsdl_s *handle);
+
+/**
+ * \fn extern uint16_t sn_nsdl_send_observation_notification(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
+ *                                                  uint8_t *payload_ptr, uint16_t payload_len,
+ *                                                  sn_coap_observe_e observe,
+ *                                                  sn_coap_msg_type_e message_type, sn_coap_content_format_e content_format)
+ *
+ *
+ * \brief Sends observation message to mbed Device Server
+ *
+ * \param   *handle         Pointer to nsdl-library handle
+ * \param   *token_ptr      Pointer to token to be used
+ * \param   token_len       Token length
+ * \param   *payload_ptr    Pointer to payload to be sent
+ * \param   payload_len     Payload length
+ * \param   observe         Observe option value to be sent
+ * \param   message_type    Observation message type (confirmable or non-confirmable)
+ * \param   content_format  Observation message payload content format
+ *
+ * \return  !0  Success, observation messages message ID
+ * \return  0   Failure
+ */
+extern uint16_t sn_nsdl_send_observation_notification(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
+        uint8_t *payload_ptr, uint16_t payload_len,
+        sn_coap_observe_e observe,
+        sn_coap_msg_type_e message_type,
+        sn_coap_content_format_e content_format);
+
+/**
+ * \fn extern uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
+ *                                                  uint8_t *payload_ptr, uint16_t payload_len,
+ *                                                  sn_coap_observe_e observe,
+ *                                                  sn_coap_msg_type_e message_type, uint8_t content_type,
+ *                                                  uint8_t *uri_path_ptr,
+ *                                                  uint16_t uri_path_len)
+ *
+ *
+ * \brief Sends observation message to mbed Device Server with uri path
+ *
+ * \param   *handle         Pointer to nsdl-library handle
+ * \param   *token_ptr      Pointer to token to be used
+ * \param   token_len       Token length
+ * \param   *payload_ptr    Pointer to payload to be sent
+ * \param   payload_len     Payload length
+ * \param   observe         Observe option value to be sent
+ * \param   message_type    Observation message type (confirmable or non-confirmable)
+ * \param   content_type    Observation message payload contetnt type
+ * \param   uri_path_ptr    Pointer to uri path to be sent
+ * \param   uri_path_len    Uri path len
+ *
+ * \return  !0  Success, observation messages message ID
+ * \return  0   Failure
+ */
+extern uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
+        uint8_t *payload_ptr, uint16_t payload_len,
+        sn_coap_observe_e observe,
+        sn_coap_msg_type_e message_type,
+        uint8_t content_type,
+        uint8_t *uri_path_ptr,
+        uint16_t uri_path_len);
+
+/**
+ * \fn extern uint32_t sn_nsdl_get_version(void)
+ *
+ * \brief Version query function.
+ *
+ * Used to retrieve the version information from the mbed Device C Client library.
+ *
+ * \return Pointer to library version string
+*/
+extern char *sn_nsdl_get_version(void);
+
+/**
+ * \fn extern int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet, uint16_t packet_len, sn_nsdl_addr_s *src)
+ *
+ * \brief To push CoAP packet to mbed Device C Client library
+ *
+ * Used to push an CoAP packet to mbed Device C Client library for processing.
+ *
+ * \param   *handle     Pointer to nsdl-library handle
+ *
+ * \param   *packet     Pointer to a uint8_t array containing the packet (including the CoAP headers).
+ *      After successful execution this array may contain the response packet.
+ *
+ * \param   *packet_len Pointer to length of the packet. After successful execution this array may contain the length
+ *      of the response packet.
+ *
+ * \param   *src        Pointer to packet source address information. After successful execution this array may contain
+ *      the destination address of the response packet.
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ */
+extern int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet, uint16_t packet_len, sn_nsdl_addr_s *src);
+
+/**
+ * \fn extern int8_t sn_nsdl_exec(struct nsdl_s *handle, uint32_t time);
+ *
+ * \brief CoAP retransmission function.
+ *
+ * Used to give execution time for the mbed Device C Client library for retransmissions.
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ *
+ * \param  time Time in seconds.
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ */
+extern int8_t sn_nsdl_exec(struct nsdl_s *handle, uint32_t time);
+
+/**
+ * \fn  extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
+ *
+ * \brief Resource creating function.
+ *
+ * Used to create a static or dynamic CoAP resource.
+ *
+ * \param   *res    Pointer to a structure of type sn_nsdl_resource_info_t that contains the information
+ *     about the resource.
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ * \return  -2  Resource already exists
+ * \return  -3  Invalid path
+ * \return  -4  List adding failure
+ */
+extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
+
+/**
+ * \fn  extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
+ *
+ * \brief Resource putting function.
+ *
+ * Used to put a static or dynamic CoAP resource without creating copy of it.
+ * NOTE: Remember that only resource will be owned, not data that it contains
+ *
+ * \param   *res    Pointer to a structure of type sn_nsdl_resource_info_t that contains the information
+ *     about the resource.
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ * \return  -2  Resource already exists
+ * \return  -3  Invalid path
+ * \return  -4  List adding failure
+ */
+extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
+
+/**
+ * \fn extern int8_t sn_nsdl_update_resource(sn_nsdl_resource_info_s *res)
+ *
+ * \brief Resource updating function.
+ *
+ * Used to update the direct value of a static resource, the callback function pointer of a dynamic resource
+ * and access rights of the recource.
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ * \param   *res    Pointer to a structure of type sn_nsdl_resource_info_t that contains the information
+ *     about the resource. Only the pathlen and path elements are evaluated along with
+ *     either resourcelen and resource or the function pointer.
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ */
+extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
+
+/**
+ * \fn extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint8_t pathlen, uint8_t *path)
+ *
+ * \brief Resource delete function.
+ *
+ * Used to delete a resource. If resource has a subresources, these all must also be removed.
+ *
+ * \param   *handle     Pointer to nsdl-library handle
+ * \param   pathlen     Contains the length of the path that is to be deleted (excluding possible trailing "\0").
+ * \param   *path_ptr   A pointer to an array containing the path.
+ *
+ * \return  0   Success
+ * \return  -1  Failure (No such resource)
+ */
+extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path);
+
+/**
+ * \fn extern sn_nsdl_resource_info_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
+ *
+ * \brief Resource get function.
+ *
+ * Used to get a resource.
+ *
+ * \param   *handle     Pointer to nsdl-library handle
+ * \param   pathlen Contains the length of the path that is to be returned (excluding possible trailing '\0').
+ * \param   *path   A pointer to an array containing the path.
+ *
+ * \return  !NULL   Success, pointer to a sn_nsdl_resource_info_s that contains the resource information\n
+ * \return  NULL    Failure
+ */
+extern sn_nsdl_resource_info_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path);
+
+/**
+ * \fn extern sn_grs_resource_list_s *sn_nsdl_list_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
+ *
+ * \brief Resource list function.
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ * \param   pathlen Contains the length of the target path (excluding possible trailing '\0').
+ *     The length value is not examined if the path itself is a NULL pointer.
+ * \param   *path   A pointer to an array containing the path or a NULL pointer.
+ *
+ * \return  !NULL   A pointer to a sn_grs_resource_list_s structure containing the resource listing.
+ * \return  NULL    Failure with an unspecified error
+ */
+sn_grs_resource_list_s *sn_nsdl_list_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path);
+
+/**
+ * \fn extern void sn_nsdl_free_resource_list(struct nsdl_s *handle, sn_grs_resource_list_s *list)
+ *
+ * \brief Free a resource list obtained from sn_nsdl_list_resource()
+ *
+ * \param   list    The list to free, or NULL.
+ */
+void sn_nsdl_free_resource_list(struct nsdl_s *handle, sn_grs_resource_list_s *list);
+
+/**
+ * \fn extern int8_t sn_nsdl_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *address_ptr, sn_coap_hdr_s *coap_hdr_ptr);
+ *
+ * \brief Send an outgoing CoAP request.
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ * \param   *address_ptr    Pointer to source address struct
+ * \param   *coap_hdr_ptr   Pointer to CoAP message to be sent
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ */
+extern int8_t sn_nsdl_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *address_ptr, sn_coap_hdr_s *coap_hdr_ptr);
+
+/**
+ * \fn extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint16_t port, sn_nsdl_addr_type_e address_type);
+ *
+ * \brief This function is used to set the mbed Device Server address given by an application.
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ * \return  0   Success
+ * \return  -1  Failed to indicate that internal address pointer is not allocated (call nsdl_init() first).
+ */
+extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint16_t port, sn_nsdl_addr_type_e address_type);
+
+/**
+ * \fn extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint8_t address_length, uint16_t port, sn_nsdl_addr_type_e address_type);
+ *
+ * \brief This function is used to set the mbed Device Server address given by an application.
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ * \return  0   Success
+ * \return  -1  Failed to indicate that internal address pointer is not allocated (call nsdl_init() first).
+ */
+extern int8_t set_NSP_address_2(struct nsdl_s *handle, uint8_t *NSP_address, uint8_t address_length, uint16_t port, sn_nsdl_addr_type_e address_type);
+
+/**
+ * \fn extern int8_t sn_nsdl_destroy(struct nsdl_s *handle);
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ * \brief This function releases all allocated memory in mbed Device C Client library.
+ */
+extern int8_t sn_nsdl_destroy(struct nsdl_s *handle);
+
+/**
+ * \fn extern uint16_t sn_nsdl_oma_bootstrap(struct nsdl_s *handle, sn_nsdl_addr_s *bootstrap_address_ptr, sn_nsdl_ep_parameters_s *endpoint_info_ptr, sn_nsdl_bs_ep_info_t *bootstrap_endpoint_info_ptr);
+ *
+ * \brief Starts OMA bootstrap process
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ *
+ * \return bootstrap message ID, 0 if failed
+ */
+extern uint16_t sn_nsdl_oma_bootstrap(struct nsdl_s *handle, sn_nsdl_addr_s *bootstrap_address_ptr, sn_nsdl_ep_parameters_s *endpoint_info_ptr, sn_nsdl_bs_ep_info_t *bootstrap_endpoint_info_ptr);
+
+/**
+ * \fn extern omalw_certificate_list_t *sn_nsdl_get_certificates(struct nsdl_s *handle);
+ *
+ * \brief Get pointer to received device server certificates
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ */
+extern omalw_certificate_list_t *sn_nsdl_get_certificates(struct nsdl_s *handle);
+
+/**
+ * \fn extern int8_t sn_nsdl_update_certificates(struct nsdl_s *handle, omalw_certificate_list_t* certificate_ptr, uint8_t certificate_chain);
+ *
+ * \brief Updates certificate pointers to resource server.
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ */
+extern int8_t sn_nsdl_update_certificates(struct nsdl_s *handle, omalw_certificate_list_t *certificate_ptr, uint8_t certificate_chain);
+
+/**
+ * \fn extern int8_t sn_nsdl_create_oma_device_object(struct nsdl_s *handle, sn_nsdl_oma_device_t *device_object_ptr);
+ *
+ * \brief Creates new device object resource
+ *
+ * \param   *handle Pointer to nsdl-library handle
+ */
+extern int8_t sn_nsdl_create_oma_device_object(struct nsdl_s *handle, sn_nsdl_oma_device_t *device_object_ptr);
+
+/**
+ * \fn sn_coap_hdr_s *sn_nsdl_build_response(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
+ *
+ * \brief Prepares generic response packet from a request packet. This function allocates memory for the resulting sn_coap_hdr_s
+ *
+ * \param *handle Pointer to library handle
+ * \param *coap_packet_ptr The request packet pointer
+ * \param msg_code response messages code
+ *
+ * \return *coap_packet_ptr The allocated and pre-filled response packet pointer
+ *          NULL    Error in parsing the request
+ *
+ */
+extern sn_coap_hdr_s *sn_nsdl_build_response(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code);
+
+/**
+ * \brief Allocates and initializes options list structure
+ *
+ * \param *handle Pointer to library handle
+ * \param *coap_msg_ptr is pointer to CoAP message that will contain the options
+ *
+ * If the message already has a pointer to an option structure, that pointer
+ * is returned, rather than a new structure being allocated.
+ *
+ * \return Return value is pointer to the CoAP options structure.\n
+ *         In following failure cases NULL is returned:\n
+ *          -Failure in given pointer (= NULL)\n
+ *          -Failure in memory allocation (malloc() returns NULL)
+ */
+extern sn_coap_options_list_s *sn_nsdl_alloc_options_list(struct nsdl_s *handle, sn_coap_hdr_s *coap_msg_ptr);
+
+/**
+ * \fn void sn_nsdl_release_allocated_coap_msg_mem(struct nsdl_s *handle, sn_coap_hdr_s *freed_coap_msg_ptr)
+ *
+ * \brief Releases memory of given CoAP message
+ *
+ *        Note!!! Does not release Payload part
+ *
+ * \param *handle Pointer to library handle
+ *
+ * \param *freed_coap_msg_ptr is pointer to released CoAP message
+ */
+extern void sn_nsdl_release_allocated_coap_msg_mem(struct nsdl_s *handle, sn_coap_hdr_s *freed_coap_msg_ptr);
+
+/**
+ * \fn int8_t sn_nsdl_set_retransmission_parameters(struct nsdl_s *handle, uint8_t resending_count, uint8_t resending_intervall)
+ *
+ * \brief  If re-transmissions are enabled, this function changes resending count and interval.
+ *
+ * \param *handle Pointer to library handle
+ * \param uint8_t resending_count max number of resendings for message
+ * \param uint8_t resending_intervall message resending intervall in seconds
+ * \return  0 = success, -1 = failure
+ */
+extern int8_t sn_nsdl_set_retransmission_parameters(struct nsdl_s *handle, uint8_t resending_count, uint8_t resending_interval);
+
+/**
+ * \fn int8_t sn_nsdl_set_retransmission_buffer(struct nsdl_s *handle, uint8_t buffer_size_messages, uint16_t buffer_size_bytes)
+ *
+ * \brief If re-transmissions are enabled, this function changes message retransmission queue size.
+ *  Set size to '0' to disable feature. If both are set to '0', then re-sendings are disabled.
+ *
+ * \param *handle Pointer to library handle
+ * \param uint8_t buffer_size_messages queue size - maximum number of messages to be saved to queue
+ * \param uint8_t buffer_size_bytes queue size - maximum size of messages saved to queue
+ * \return  0 = success, -1 = failure
+ */
+extern int8_t sn_nsdl_set_retransmission_buffer(struct nsdl_s *handle,
+        uint8_t buffer_size_messages, uint16_t buffer_size_bytes);
+
+/**
+ * \fn int8_t sn_nsdl_set_block_size(struct nsdl_s *handle, uint16_t block_size)
+ *
+ * \brief If block transfer is enabled, this function changes the block size.
+ *
+ * \param *handle Pointer to library handle
+ * \param uint16_t block_size maximum size of CoAP payload. Valid sizes are 16, 32, 64, 128, 256, 512 and 1024 bytes
+ * \return  0 = success, -1 = failure
+ */
+extern int8_t sn_nsdl_set_block_size(struct nsdl_s *handle, uint16_t block_size);
+
+/**
+ * \fn int8_t sn_nsdl_set_duplicate_buffer_size(struct nsdl_s *handle,uint8_t message_count)
+ *
+ * \brief If dublicate message detection is enabled, this function changes buffer size.
+ *
+ * \param *handle Pointer to library handle
+ * \param uint8_t message_count max number of messages saved for duplicate control
+ * \return  0 = success, -1 = failure
+ */
+extern int8_t sn_nsdl_set_duplicate_buffer_size(struct nsdl_s *handle, uint8_t message_count);
+
+/**
+ * \fn void *sn_nsdl_set_context(const struct nsdl_s *handle, void *context)
+ *
+ * \brief Set the application defined context parameter for given handle.
+ *        This is useful for example when interfacing with c++ objects where a
+ *        pointer to object is set as the context, and in the callback functions
+ *        the context pointer can be used to call methods for the correct instance
+ *        of the c++ object.
+ *
+ * \param *handle Pointer to library handle
+ * \param *context Pointer to the application defined context
+ * \return 0 = success, -1 = failure
+ */
+extern int8_t sn_nsdl_set_context(struct nsdl_s * const handle, void * const context);
+
+/**
+ * \fn void *sn_nsdl_get_context(const struct nsdl_s *handle)
+ *
+ * \brief Get the application defined context parameter for given handle.
+ *        This is useful for example when interfacing with c++ objects where a
+ *        pointer to object is set as the context, and in the callback functions
+ *        the context pointer can be used to call methods for the correct instance
+ *        of the c++ object.
+ *
+ * \param *handle Pointer to library handle
+ * \return Pointer to the application defined context
+ */
+extern void *sn_nsdl_get_context(const struct nsdl_s * const handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SN_NSDL_LIB_H_ */

--- a/nsdl-c/sn_nsdl_lib2.h
+++ b/nsdl-c/sn_nsdl_lib2.h
@@ -25,7 +25,7 @@
 #ifndef SN_NSDL_LIB_H_
 #define SN_NSDL_LIB_H_
 
-#include "ns_list.h"
+#include "mbed-client-libservice/ns_list.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,6 +33,7 @@ extern "C" {
 
 #define SN_NSDL_ENDPOINT_NOT_REGISTERED  0
 #define SN_NSDL_ENDPOINT_IS_REGISTERED   1
+
 
 /* Handle structure */
 struct nsdl_s;
@@ -68,15 +69,6 @@ typedef enum sn_nsdl_registration_mode_ {
     REGISTER_WITH_RESOURCES = 0,
     REGISTER_WITH_TEMPLATE
 } sn_nsdl_registration_mode_t;
-
-
-typedef struct omalw_certificate_list_ {
-    uint8_t  certificate_chain_len;
-    uint16_t own_private_key_len;
-    uint16_t certificate_len[2];
-    uint8_t  *certificate_ptr[2];
-    uint8_t  *own_private_key_ptr;
-} omalw_certificate_list_t;
 
 /**
  * \brief Endpoint registration parameters
@@ -119,7 +111,7 @@ typedef struct sn_grs_resource_ {
  * \brief Table of created resources
  */
 typedef struct sn_grs_resource_list_ {
-    uint8_t res_count;                  /**< Number of resources */
+    uint8_t res_count; /**< Number of resources */
     sn_grs_resource_s *res;
 } sn_grs_resource_list_s;
 
@@ -133,19 +125,6 @@ typedef enum sn_grs_resource_acl_ {
     SN_GRS_DELETE_ALLOWED   = 0x08
 } sn_grs_resource_acl_e;
 
-
-typedef enum sn_nsdl_oma_device_error_ {
-    NO_ERROR = 0,
-    LOW_BATTERY_POWER = 1,
-    EXTERNAL_POWER_SUPPLY_OFF = 2,
-    GPS_MODULE_FAILURE = 3,
-    LOW_RECEIVED_SIGNAL_STRENGTH = 4,
-    OUT_OF_MEMORY = 5,
-    SMS_FAILURE = 6,
-    IP_CONN_FAILURE = 7,
-    PERIPHERAL_MALFUNCTION = 8
-} sn_nsdl_oma_device_error_t;
-
 /**
  * \brief Defines the resource mode
  */
@@ -156,61 +135,44 @@ typedef enum sn_nsdl_resource_mode_ {
 } sn_nsdl_resource_mode_e;
 
 /**
- * \brief Resource registration parameters
+ * \brief Defines static parameters for the resource.
+ */
+typedef struct sn_nsdl_static_resource_parameters_ {
+    char        *resource_type_ptr;         //
+    char        *interface_description_ptr; //
+    uint8_t     *path;                      // convert to char*?
+    uint8_t     *resource;                  /**< NULL if dynamic resource */
+    int16_t     pathlen;                    /**< Address */ // Check type
+    uint16_t    resourcelen;                /**< 0 if dynamic resource, resource information in static resource */
+    bool        external_memory_block:1;    /**< 0 means block messages are handled inside this library,
+                                                 otherwise block messages are passed to application */
+    unsigned    mode:2;                     /**< STATIC etc.. */
+    bool        free_on_delete:1;           /**< 1 if struct is dynamic allocted --> to be freed */
+} sn_nsdl_static_resource_parameters_s;
+
+/**
+ * \brief Defines dynamic parameters for the resource.
  */
 typedef struct sn_nsdl_resource_parameters_ {
-    unsigned int     observable:2;
-    unsigned int     registered:2;
-
-    uint16_t    resource_type_len;
-    uint16_t    interface_description_len;
-
-    uint16_t    coap_content_type;
-//    uint8_t     mime_content_type;
-
-    uint8_t     *resource_type_ptr;
-    uint8_t     *interface_description_ptr;
-
-} sn_nsdl_resource_parameters_s;
-
-/**
- * \brief Defines parameters for the resource.
- */
-typedef struct sn_nsdl_resource_info_ {
-
-    unsigned int                    mode:2;                     /**< STATIC etc.. */
-
-    unsigned int                    access:4;
-
-    bool                            publish_uri:1;
-
-    bool                            is_put:1; //if true, pointers are assumed to be consts (never freed). Note: resource_parameters_ptr is always freed!
-
-    uint8_t                         external_memory_block;
-
-    uint16_t                        pathlen;                    /**< Address */
-
-    uint16_t                        resourcelen;                /**< 0 if dynamic resource, resource information in static resource */
-
-    sn_nsdl_resource_parameters_s   *resource_parameters_ptr;
-
-    uint8_t (*sn_grs_dyn_res_callback)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *, sn_nsdl_capab_e);
-
-    uint8_t                         *path;
-
-    uint8_t                         *resource;                  /**< NULL if dynamic resource */
-
-    ns_list_link_t                  link;
-} sn_nsdl_resource_info_s;
-
-/**
- * \brief Defines OMA device object parameters.
- */
-typedef struct sn_nsdl_oma_device_ {
-    sn_nsdl_oma_device_error_t error_code;                                                                          /**< Error code. Mandatory. Can be more than one */
-    uint8_t (*sn_oma_device_boot_callback)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *, sn_nsdl_capab_e);    /**< Device boot callback function. If defined, this is called when reset request is received */
-
-} sn_nsdl_oma_device_t;
+    uint8_t                                     (*sn_grs_dyn_res_callback)(struct nsdl_s *,
+                                                                       sn_coap_hdr_s *,
+                                                                       sn_nsdl_addr_s *,
+                                                                       sn_nsdl_capab_e);
+#ifdef MEMORY_OPTIMIZED_API
+    const sn_nsdl_static_resource_parameters_s  *static_resource_parameters;
+#else
+    sn_nsdl_static_resource_parameters_s        *static_resource_parameters;
+#endif
+    ns_list_link_t                              link;
+    uint16_t                                    coap_content_type;  /**< CoAP content type */
+    unsigned                                    access:4;           /**< Allowed operation mode, GET, PUT, etc,
+                                                                         TODO! This should be in static struct but current
+                                                                         mbed-client implementation requires this to be changed at runtime */
+    unsigned                                    registered:2;       /**< Is resource registered or not */
+    bool                                        publish_uri:1;      /**< 1 if resource to be published to server */
+    bool                                        free_on_delete:1;   /**< 1 if struct is dynamic allocted --> to be freed */
+    bool                                        observable:1;       /**< Is resource observable or not */
+} sn_nsdl_dynamic_resource_parameters_s;
 
 /**
  * \brief Defines OMAlw server information
@@ -228,13 +190,8 @@ typedef struct sn_nsdl_bs_ep_info_ {
     void (*oma_bs_status_cb)(sn_nsdl_oma_server_info_t *);  /**< Callback for OMA bootstrap status */
 
     void (*oma_bs_status_cb_handle)(sn_nsdl_oma_server_info_t *,
-                                    struct nsdl_s *);  /**< Callback for OMA bootstrap status with nsdl handle */
-
-    sn_nsdl_oma_device_t *device_object;                    /**< OMA LWM2M mandatory device resources */
+                                    struct nsdl_s *);       /**< Callback for OMA bootstrap status with nsdl handle */
 } sn_nsdl_bs_ep_info_t;
-
-
-
 
 /**
  * \fn struct nsdl_s *sn_nsdl_init  (uint8_t (*sn_nsdl_tx_cb)(sn_nsdl_capab_e , uint8_t *, uint16_t, sn_nsdl_addr_s *),
@@ -304,7 +261,6 @@ extern uint16_t sn_nsdl_update_registration(struct nsdl_s *handle, uint8_t *lt_p
  */
 extern int8_t sn_nsdl_set_endpoint_location(struct nsdl_s *handle, uint8_t *location_ptr, uint8_t location_len);
 
-
 /**
  * \fn extern int8_t sn_nsdl_is_ep_registered(struct nsdl_s *handle)
  *
@@ -356,39 +312,6 @@ extern uint16_t sn_nsdl_send_observation_notification(struct nsdl_s *handle, uin
         sn_coap_content_format_e content_format);
 
 /**
- * \fn extern uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
- *                                                  uint8_t *payload_ptr, uint16_t payload_len,
- *                                                  sn_coap_observe_e observe,
- *                                                  sn_coap_msg_type_e message_type, uint8_t content_type,
- *                                                  uint8_t *uri_path_ptr,
- *                                                  uint16_t uri_path_len)
- *
- *
- * \brief Sends observation message to mbed Device Server with uri path
- *
- * \param   *handle         Pointer to nsdl-library handle
- * \param   *token_ptr      Pointer to token to be used
- * \param   token_len       Token length
- * \param   *payload_ptr    Pointer to payload to be sent
- * \param   payload_len     Payload length
- * \param   observe         Observe option value to be sent
- * \param   message_type    Observation message type (confirmable or non-confirmable)
- * \param   content_type    Observation message payload contetnt type
- * \param   uri_path_ptr    Pointer to uri path to be sent
- * \param   uri_path_len    Uri path len
- *
- * \return  !0  Success, observation messages message ID
- * \return  0   Failure
- */
-extern uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
-        uint8_t *payload_ptr, uint16_t payload_len,
-        sn_coap_observe_e observe,
-        sn_coap_msg_type_e message_type,
-        uint8_t content_type,
-        uint8_t *uri_path_ptr,
-        uint16_t uri_path_len);
-
-/**
  * \fn extern uint32_t sn_nsdl_get_version(void)
  *
  * \brief Version query function.
@@ -438,8 +361,9 @@ extern int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet, uint1
  */
 extern int8_t sn_nsdl_exec(struct nsdl_s *handle, uint32_t time);
 
+#ifndef MEMORY_OPTIMIZED_API
 /**
- * \fn  extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
+ * \fn  extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, const sn_nsdl_resource_parameters_s *res);
  *
  * \brief Resource creating function.
  *
@@ -454,29 +378,10 @@ extern int8_t sn_nsdl_exec(struct nsdl_s *handle, uint32_t time);
  * \return  -3  Invalid path
  * \return  -4  List adding failure
  */
-extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
+extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
 
 /**
- * \fn  extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
- *
- * \brief Resource putting function.
- *
- * Used to put a static or dynamic CoAP resource without creating copy of it.
- * NOTE: Remember that only resource will be owned, not data that it contains
- *
- * \param   *res    Pointer to a structure of type sn_nsdl_resource_info_t that contains the information
- *     about the resource.
- *
- * \return  0   Success
- * \return  -1  Failure
- * \return  -2  Resource already exists
- * \return  -3  Invalid path
- * \return  -4  List adding failure
- */
-extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
-
-/**
- * \fn extern int8_t sn_nsdl_update_resource(sn_nsdl_resource_info_s *res)
+ * \fn extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_resource_parameters_s *res)
  *
  * \brief Resource updating function.
  *
@@ -491,7 +396,45 @@ extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_resource_info_
  * \return  0   Success
  * \return  -1  Failure
  */
-extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res);
+extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
+#endif
+
+/**
+ * \fn  extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, const sn_nsdl_dynamic_resource_parameters_s *res);
+ *
+ * \brief Resource putting function.
+ *
+ * Used to put a static or dynamic CoAP resource without creating copy of it.
+ * NOTE: Remember that only resource will be owned, not data that it contains
+ * NOTE: The resource may be removed from list by sn_nsdl_pop_resource().
+ *
+ * \param   *res    Pointer to a structure of type sn_nsdl_dynamic_resource_parameters_s that contains the information
+ *     about the resource.
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ * \return  -2  Resource already exists
+ * \return  -3  Invalid path
+ * \return  -4  List adding failure
+ */
+extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
+
+/**
+ * \fn  extern int8_t sn_nsdl_pop_resource(struct nsdl_s *handle, const sn_nsdl_dynamic_resource_parameters_s *res);
+ *
+ * \brief Resource popping function.
+ *
+ * Used to remove a static or dynamic CoAP resource from lists without deleting it.
+ * NOTE: This function is a counterpart of sn_nsdl_put_resource().
+ *
+ * \param   *res    Pointer to a structure of type sn_nsdl_dynamic_resource_parameters_s that contains the information
+ *     about the resource.
+ *
+ * \return  0   Success
+ * \return  -1  Failure
+ * \return  -3  Invalid path
+ */
+extern int8_t sn_nsdl_pop_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
 
 /**
  * \fn extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint8_t pathlen, uint8_t *path)
@@ -510,7 +453,7 @@ extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_resource_in
 extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path);
 
 /**
- * \fn extern sn_nsdl_resource_info_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
+ * \fn extern sn_nsdl_dynamic_resource_parameters_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
  *
  * \brief Resource get function.
  *
@@ -520,10 +463,10 @@ extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint16_t pathlen, u
  * \param   pathlen Contains the length of the path that is to be returned (excluding possible trailing '\0').
  * \param   *path   A pointer to an array containing the path.
  *
- * \return  !NULL   Success, pointer to a sn_nsdl_resource_info_s that contains the resource information\n
+ * \return  !NULL   Success, pointer to a sn_nsdl_dynamic_resource_parameters_s that contains the resource information\n
  * \return  NULL    Failure
  */
-extern sn_nsdl_resource_info_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path);
+extern sn_nsdl_dynamic_resource_parameters_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path);
 
 /**
  * \fn extern sn_grs_resource_list_s *sn_nsdl_list_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
@@ -564,17 +507,6 @@ void sn_nsdl_free_resource_list(struct nsdl_s *handle, sn_grs_resource_list_s *l
 extern int8_t sn_nsdl_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *address_ptr, sn_coap_hdr_s *coap_hdr_ptr);
 
 /**
- * \fn extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint16_t port, sn_nsdl_addr_type_e address_type);
- *
- * \brief This function is used to set the mbed Device Server address given by an application.
- *
- * \param   *handle Pointer to nsdl-library handle
- * \return  0   Success
- * \return  -1  Failed to indicate that internal address pointer is not allocated (call nsdl_init() first).
- */
-extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint16_t port, sn_nsdl_addr_type_e address_type);
-
-/**
  * \fn extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint8_t address_length, uint16_t port, sn_nsdl_addr_type_e address_type);
  *
  * \brief This function is used to set the mbed Device Server address given by an application.
@@ -583,7 +515,7 @@ extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint1
  * \return  0   Success
  * \return  -1  Failed to indicate that internal address pointer is not allocated (call nsdl_init() first).
  */
-extern int8_t set_NSP_address_2(struct nsdl_s *handle, uint8_t *NSP_address, uint8_t address_length, uint16_t port, sn_nsdl_addr_type_e address_type);
+extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint8_t address_length, uint16_t port, sn_nsdl_addr_type_e address_type);
 
 /**
  * \fn extern int8_t sn_nsdl_destroy(struct nsdl_s *handle);
@@ -603,33 +535,6 @@ extern int8_t sn_nsdl_destroy(struct nsdl_s *handle);
  * \return bootstrap message ID, 0 if failed
  */
 extern uint16_t sn_nsdl_oma_bootstrap(struct nsdl_s *handle, sn_nsdl_addr_s *bootstrap_address_ptr, sn_nsdl_ep_parameters_s *endpoint_info_ptr, sn_nsdl_bs_ep_info_t *bootstrap_endpoint_info_ptr);
-
-/**
- * \fn extern omalw_certificate_list_t *sn_nsdl_get_certificates(struct nsdl_s *handle);
- *
- * \brief Get pointer to received device server certificates
- *
- * \param   *handle Pointer to nsdl-library handle
- */
-extern omalw_certificate_list_t *sn_nsdl_get_certificates(struct nsdl_s *handle);
-
-/**
- * \fn extern int8_t sn_nsdl_update_certificates(struct nsdl_s *handle, omalw_certificate_list_t* certificate_ptr, uint8_t certificate_chain);
- *
- * \brief Updates certificate pointers to resource server.
- *
- * \param   *handle Pointer to nsdl-library handle
- */
-extern int8_t sn_nsdl_update_certificates(struct nsdl_s *handle, omalw_certificate_list_t *certificate_ptr, uint8_t certificate_chain);
-
-/**
- * \fn extern int8_t sn_nsdl_create_oma_device_object(struct nsdl_s *handle, sn_nsdl_oma_device_t *device_object_ptr);
- *
- * \brief Creates new device object resource
- *
- * \param   *handle Pointer to nsdl-library handle
- */
-extern int8_t sn_nsdl_create_oma_device_object(struct nsdl_s *handle, sn_nsdl_oma_device_t *device_object_ptr);
 
 /**
  * \fn sn_coap_hdr_s *sn_nsdl_build_response(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)

--- a/source/libNsdl/src/include/sn_grs.h
+++ b/source/libNsdl/src/include/sn_grs.h
@@ -16,6 +16,11 @@
 #ifndef GRS_H_
 #define GRS_H_
 
+#ifdef MBED_CLIENT_C_NEW_API
+
+#include "sn_grs2.h"
+
+#else
 
 #ifdef __cplusplus
 extern "C" {
@@ -131,7 +136,7 @@ extern void                             sn_grs_mark_resources_as_registered(stru
 }
 #endif
 
-
+#endif /* MBED_CLIENT_C_NEW_API */
 
 
 #endif /* GRS_H_ */

--- a/source/libNsdl/src/include/sn_grs2.h
+++ b/source/libNsdl/src/include/sn_grs2.h
@@ -46,7 +46,7 @@ typedef struct sn_grs_version_ {
     uint8_t build;
 } sn_grs_version_s;
 
-typedef NS_LIST_HEAD(sn_nsdl_resource_info_s, link) resource_list_t;
+typedef NS_LIST_HEAD(sn_nsdl_dynamic_resource_parameters_s, link) resource_list_t;
 
 struct grs_s {
     struct coap_s *coap;
@@ -73,7 +73,6 @@ struct nsdl_s {
     uint16_t oma_bs_port;                                                       /* Bootstrap port */
     uint8_t oma_bs_address_len;                                                 /* Bootstrap address length */
     unsigned int sn_nsdl_endpoint_registered:1;
-    bool handle_bootstrap_msg:1;
 
     struct grs_s *grs;
     uint8_t *oma_bs_address_ptr;                                                /* Bootstrap address pointer. If null, no bootstrap in use */
@@ -111,21 +110,35 @@ struct nsdl_s {
  *
 */
 extern struct grs_s *sn_grs_init(uint8_t (*sn_grs_tx_callback_ptr)(struct nsdl_s *, sn_nsdl_capab_e , uint8_t *, uint16_t,
-                                 sn_nsdl_addr_s *), int8_t (*sn_grs_rx_callback_ptr)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *), void *(*sn_grs_alloc)(uint16_t), void (*sn_grs_free)(void *));
+                                 sn_nsdl_addr_s *),
+                                 int8_t (*sn_grs_rx_callback_ptr)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *),
+                                 void *(*sn_grs_alloc)(uint16_t),
+                                 void (*sn_grs_free)(void *));
 
-extern const sn_nsdl_resource_info_s    *sn_grs_get_first_resource(struct grs_s *handle);
-extern const sn_nsdl_resource_info_s    *sn_grs_get_next_resource(struct grs_s *handle, const sn_nsdl_resource_info_s *sn_grs_current_resource);
-extern int8_t                           sn_grs_process_coap(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, sn_nsdl_addr_s *src);
-extern sn_nsdl_resource_info_s          *sn_grs_search_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path, uint8_t search_method);
-extern int8_t                           sn_grs_destroy(struct grs_s *handle);
-extern sn_grs_resource_list_s           *sn_grs_list_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path);
-extern void                             sn_grs_free_resource_list(struct grs_s *handle, sn_grs_resource_list_s *list);
-extern int8_t                           sn_grs_update_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res);
-extern int8_t                           sn_grs_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *address_ptr, sn_coap_hdr_s *coap_hdr_ptr);
-extern int8_t                           sn_grs_create_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res);
-extern int8_t                           sn_grs_put_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res);
-extern int8_t                           sn_grs_delete_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path);
-extern void                             sn_grs_mark_resources_as_registered(struct nsdl_s *handle);
+extern sn_nsdl_dynamic_resource_parameters_s    *sn_grs_get_first_resource(struct grs_s *handle);
+extern sn_nsdl_dynamic_resource_parameters_s    *sn_grs_get_next_resource(struct grs_s *handle,
+                                                                          const sn_nsdl_dynamic_resource_parameters_s *sn_grs_current_resource);
+extern int8_t                                   sn_grs_process_coap(struct nsdl_s *handle,
+                                                                    sn_coap_hdr_s *coap_packet_ptr,
+                                                                    sn_nsdl_addr_s *src);
+extern sn_nsdl_dynamic_resource_parameters_s    *sn_grs_search_resource(struct grs_s *handle,
+                                                                        uint16_t pathlen,
+                                                                        uint8_t *path,
+                                                                        uint8_t search_method);
+extern int8_t                                   sn_grs_destroy(struct grs_s *handle);
+extern sn_grs_resource_list_s                   *sn_grs_list_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path);
+extern void                                     sn_grs_free_resource_list(struct grs_s *handle, sn_grs_resource_list_s *list);
+extern int8_t                                   sn_grs_send_coap_message(struct nsdl_s *handle,
+                                                                         sn_nsdl_addr_s *address_ptr,
+                                                                         sn_coap_hdr_s *coap_hdr_ptr);
+extern int8_t                                   sn_grs_put_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
+extern int8_t                                   sn_grs_pop_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
+extern int8_t                                   sn_grs_delete_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path);
+extern void                                     sn_grs_mark_resources_as_registered(struct nsdl_s *handle);
+#ifndef MEMORY_OPTIMIZED_API
+extern int8_t                                   sn_grs_create_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
+extern int8_t                                   sn_grs_update_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res);
+#endif
 
 #ifdef __cplusplus
 }

--- a/source/libNsdl/src/include/sn_grs2.h
+++ b/source/libNsdl/src/include/sn_grs2.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2011-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GRS_H_
+#define GRS_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define SN_GRS_RESOURCE_ALREADY_EXISTS  -2
+#define SN_GRS_INVALID_PATH             -3
+#define SN_GRS_LIST_ADDING_FAILURE      -4
+#define SN_GRS_RESOURCE_UPDATED     -5
+
+#define ACCESS_DENIED           -6
+
+#define SN_GRS_DELETE_METHOD    0
+#define SN_GRS_SEARCH_METHOD    1
+
+#define SN_GRS_DEFAULT_ACCESS   0x0F
+
+#define SN_NDSL_RESOURCE_NOT_REGISTERED 0
+#define SN_NDSL_RESOURCE_REGISTERING    1
+#define SN_NDSL_RESOURCE_REGISTERED     2
+
+/***** Structs *****/
+
+typedef struct sn_grs_version_ {
+    uint8_t major_version;
+    uint8_t minor_version;
+    uint8_t build;
+} sn_grs_version_s;
+
+typedef NS_LIST_HEAD(sn_nsdl_resource_info_s, link) resource_list_t;
+
+struct grs_s {
+    struct coap_s *coap;
+
+    void *(*sn_grs_alloc)(uint16_t);
+    void (*sn_grs_free)(void *);
+    uint8_t (*sn_grs_tx_callback)(struct nsdl_s *, sn_nsdl_capab_e , uint8_t *, uint16_t, sn_nsdl_addr_s *);
+    int8_t (*sn_grs_rx_callback)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *);
+
+    uint16_t resource_root_count;
+    resource_list_t resource_root_list;
+};
+
+
+struct nsdl_s {
+    uint16_t update_register_msg_id;
+    uint16_t register_msg_len;
+    uint16_t update_register_msg_len;
+
+    uint16_t register_msg_id;
+    uint16_t unregister_msg_id;
+
+    uint16_t bootstrap_msg_id;
+    uint16_t oma_bs_port;                                                       /* Bootstrap port */
+    uint8_t oma_bs_address_len;                                                 /* Bootstrap address length */
+    unsigned int sn_nsdl_endpoint_registered:1;
+    bool handle_bootstrap_msg:1;
+
+    struct grs_s *grs;
+    uint8_t *oma_bs_address_ptr;                                                /* Bootstrap address pointer. If null, no bootstrap in use */
+    sn_nsdl_ep_parameters_s *ep_information_ptr;                                // Endpoint parameters, Name, Domain etc..
+    sn_nsdl_oma_server_info_t *nsp_address_ptr;                                 // NSP server address information
+    /* Application definable context. This is useful for example when interfacing with c++ objects where a pointer to object is set as the
+     * context, and in the callback functions the context pointer can be used to call methods for the correct instance of the c++ object. */
+    void *context;
+
+    void (*sn_nsdl_oma_bs_done_cb)(sn_nsdl_oma_server_info_t *server_info_ptr); /* Callback to inform application when bootstrap is done */
+    void *(*sn_nsdl_alloc)(uint16_t);
+    void (*sn_nsdl_free)(void *);
+    uint8_t (*sn_nsdl_tx_callback)(struct nsdl_s *, sn_nsdl_capab_e , uint8_t *, uint16_t, sn_nsdl_addr_s *);
+    uint8_t (*sn_nsdl_rx_callback)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *);
+    void (*sn_nsdl_oma_bs_done_cb_handle)(sn_nsdl_oma_server_info_t *server_info_ptr,
+                                          struct nsdl_s *handle); /* Callback to inform application when bootstrap is done with nsdl handle */
+};
+
+/***** Function prototypes *****/
+/**
+ *  \fn extern grs_s *sn_grs_init   (uint8_t (*sn_grs_tx_callback_ptr)(sn_nsdl_capab_e , uint8_t *, uint16_t,
+ *                                  sn_nsdl_addr_s *), uint8_t (*sn_grs_rx_callback_ptr)(sn_coap_hdr_s *, sn_nsdl_addr_s *),
+ *                                  sn_grs_mem_s *sn_memory)
+ *
+ *  \brief GRS library initialize function.
+ *
+ *  This function initializes GRS and CoAP.
+ *
+ *  \param  sn_grs_tx_callback      A function pointer to a transmit callback function. Should return 1 when succeed, 0 when failed
+ *  \param  *sn_grs_rx_callback_ptr A function pointer to a receiving callback function. If received packet is not for GRS, it will be passed to
+ *                                  upper level (NSDL) to be proceed.
+ *  \param  sn_memory               A pointer to a structure containing the platform specific functions for memory allocation and free.
+ *
+ *  \return success pointer to handle, failure = NULL
+ *
+*/
+extern struct grs_s *sn_grs_init(uint8_t (*sn_grs_tx_callback_ptr)(struct nsdl_s *, sn_nsdl_capab_e , uint8_t *, uint16_t,
+                                 sn_nsdl_addr_s *), int8_t (*sn_grs_rx_callback_ptr)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *), void *(*sn_grs_alloc)(uint16_t), void (*sn_grs_free)(void *));
+
+extern const sn_nsdl_resource_info_s    *sn_grs_get_first_resource(struct grs_s *handle);
+extern const sn_nsdl_resource_info_s    *sn_grs_get_next_resource(struct grs_s *handle, const sn_nsdl_resource_info_s *sn_grs_current_resource);
+extern int8_t                           sn_grs_process_coap(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, sn_nsdl_addr_s *src);
+extern sn_nsdl_resource_info_s          *sn_grs_search_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path, uint8_t search_method);
+extern int8_t                           sn_grs_destroy(struct grs_s *handle);
+extern sn_grs_resource_list_s           *sn_grs_list_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path);
+extern void                             sn_grs_free_resource_list(struct grs_s *handle, sn_grs_resource_list_s *list);
+extern int8_t                           sn_grs_update_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res);
+extern int8_t                           sn_grs_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *address_ptr, sn_coap_hdr_s *coap_hdr_ptr);
+extern int8_t                           sn_grs_create_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res);
+extern int8_t                           sn_grs_put_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res);
+extern int8_t                           sn_grs_delete_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path);
+extern void                             sn_grs_mark_resources_as_registered(struct nsdl_s *handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+
+
+#endif /* GRS_H_ */

--- a/source/libNsdl/src/include/sn_grs2.h
+++ b/source/libNsdl/src/include/sn_grs2.h
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef GRS_H_
-#define GRS_H_
+#ifndef GRS_2_H_
+#define GRS_2_H_
 
+#ifdef MBED_CLIENT_C_NEW_API
 
 #ifdef __cplusplus
 extern "C" {
@@ -144,7 +145,6 @@ extern int8_t                                   sn_grs_update_resource(struct gr
 }
 #endif
 
-
-
+#endif /* MBED_CLIENT_C_NEW_API */
 
 #endif /* GRS_H_ */

--- a/source/libNsdl/src/sn_grs.c
+++ b/source/libNsdl/src/sn_grs.c
@@ -21,6 +21,9 @@
  * \brief General resource server.
  *
  */
+
+#ifndef MBED_CLIENT_C_NEW_API
+
 #include <string.h>
 #include <stdlib.h>
 
@@ -1035,3 +1038,5 @@ void sn_grs_mark_resources_as_registered(struct nsdl_s *handle)
         temp_resource = sn_grs_get_next_resource(handle->grs, temp_resource);
     }
 }
+
+#endif

--- a/source/libNsdl/src/sn_grs2.c
+++ b/source/libNsdl/src/sn_grs2.c
@@ -1,0 +1,1037 @@
+/*
+ * Copyright (c) 2011-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ *
+ * \file sn_grs.c
+ *
+ * \brief General resource server.
+ *
+ */
+#include <string.h>
+#include <stdlib.h>
+
+#include "ns_list.h"
+#include "ns_types.h"
+#include "sn_nsdl.h"
+#include "sn_coap_header.h"
+#include "sn_coap_protocol.h"
+#include "sn_coap_protocol_internal.h"
+#include "sn_nsdl_lib.h"
+#include "sn_grs.h"
+#include "mbed-trace/mbed_trace.h"
+
+/* Defines */
+#define TRACE_GROUP "coap"
+#define WELLKNOWN_PATH_LEN              16
+#define WELLKNOWN_PATH                  (".well-known/core")
+
+/* Local static function prototypes */
+static int8_t                       sn_grs_resource_info_free(struct grs_s *handle, sn_nsdl_resource_info_s *resource_ptr);
+static uint8_t                     *sn_grs_convert_uri(uint16_t *uri_len, uint8_t *uri_ptr);
+static int8_t                       sn_grs_add_resource_to_list(struct grs_s *handle, sn_nsdl_resource_info_s *resource_ptr);
+static int8_t                       sn_grs_core_request(struct nsdl_s *handle, sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *coap_packet_ptr);
+static uint8_t                      coap_tx_callback(uint8_t *, uint16_t, sn_nsdl_addr_s *, void *);
+static int8_t                       coap_rx_callback(sn_coap_hdr_s *coap_ptr, sn_nsdl_addr_s *address_ptr, void *param);
+
+/* Extern function prototypes */
+extern int8_t                       sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *message_ptr, uint8_t updating_registeration);
+
+/**
+ * \fn int8_t sn_grs_destroy(void)
+ * \brief This function may be used to flush GRS related stuff when a program exits.
+ * @return always 0.
+ */
+extern int8_t sn_grs_destroy(struct grs_s *handle)
+{
+    if( handle == NULL ){
+        return 0;
+    }
+    ns_list_foreach_safe(sn_nsdl_resource_info_s, tmp, &handle->resource_root_list) {
+        ns_list_remove(&handle->resource_root_list, tmp);
+        --handle->resource_root_count;
+        sn_grs_resource_info_free(handle, tmp);
+    }
+    handle->sn_grs_free(handle);
+
+    return 0;
+}
+
+static uint8_t coap_tx_callback(uint8_t *data_ptr, uint16_t data_len, sn_nsdl_addr_s *address_ptr, void *param)
+{
+    struct nsdl_s *handle = (struct nsdl_s *)param;
+
+    if (handle == NULL) {
+        return 0;
+    }
+
+    return handle->grs->sn_grs_tx_callback(handle, SN_NSDL_PROTOCOL_COAP, data_ptr, data_len, address_ptr);
+}
+
+static int8_t coap_rx_callback(sn_coap_hdr_s *coap_ptr, sn_nsdl_addr_s *address_ptr, void *param)
+{
+    struct nsdl_s *handle = (struct nsdl_s *)param;
+
+    if (handle == NULL) {
+        return 0;
+    }
+
+    return handle->sn_nsdl_rx_callback(handle, coap_ptr, address_ptr);
+}
+
+/**
+ * \fn int8_t sn_grs_init   (uint8_t (*sn_grs_tx_callback_ptr)(sn_nsdl_capab_e , uint8_t *, uint16_t,
+ *      sn_nsdl_addr_s *), int8_t (*sn_grs_rx_callback_ptr)(sn_coap_hdr_s *, sn_nsdl_addr_s *), sn_nsdl_mem_s *sn_memory)
+ *
+ * \brief GRS library initialize function.
+ *
+ * This function initializes GRS and CoAP libraries.
+ *
+ * \param   sn_grs_tx_callback      A function pointer to a transmit callback function.
+ * \param  *sn_grs_rx_callback_ptr A function pointer to a receiving callback function. If received packet is not for GRS, it will be passed to
+ *                                  upper level (NSDL) to be proceed.
+ * \param   sn_memory               A pointer to a structure containing the platform specific functions for memory allocation and free.
+ *
+ * \return success = 0, failure = -1
+ *
+*/
+extern struct grs_s *sn_grs_init(uint8_t (*sn_grs_tx_callback_ptr)(struct nsdl_s *, sn_nsdl_capab_e , uint8_t *, uint16_t,
+                                 sn_nsdl_addr_s *), int8_t (*sn_grs_rx_callback_ptr)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *),
+                                 void *(*sn_grs_alloc)(uint16_t), void (*sn_grs_free)(void *))
+{
+
+    struct grs_s *handle_ptr = NULL;
+
+    /* Check parameters */
+    if (sn_grs_alloc == NULL || sn_grs_free == NULL ||
+        sn_grs_tx_callback_ptr == NULL || sn_grs_rx_callback_ptr == NULL) {
+        return NULL;
+    }
+
+    handle_ptr = sn_grs_alloc(sizeof(struct grs_s));
+
+    if (handle_ptr == NULL) {
+        return NULL;
+    }
+
+    memset(handle_ptr, 0, sizeof(struct grs_s));
+
+    /* Allocation and free - function pointers  */
+    handle_ptr->sn_grs_alloc = sn_grs_alloc;
+    handle_ptr->sn_grs_free = sn_grs_free;
+
+    /* TX callback function pointer */
+    handle_ptr->sn_grs_tx_callback = sn_grs_tx_callback_ptr;
+    handle_ptr->sn_grs_rx_callback = sn_grs_rx_callback_ptr;
+
+    /* Initialize CoAP protocol library */
+    handle_ptr->coap = sn_coap_protocol_init(sn_grs_alloc, sn_grs_free, coap_tx_callback, coap_rx_callback);
+
+    return handle_ptr;
+}
+
+
+extern sn_grs_resource_list_s *sn_grs_list_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path)
+{
+    (void) pathlen;
+    sn_grs_resource_list_s *grs_resource_list_ptr = NULL;
+
+    if( handle == NULL || path == NULL){
+        return NULL;
+    }
+
+    /* Allocate memory for the resource list to be filled */
+    grs_resource_list_ptr = handle->sn_grs_alloc(sizeof(sn_grs_resource_list_s));
+    if (!grs_resource_list_ptr) {
+        goto fail;
+    }
+
+    /* Count resources to the resource list struct */
+    grs_resource_list_ptr->res_count = handle->resource_root_count;
+    grs_resource_list_ptr->res = NULL;
+
+    /**************************************/
+    /* Fill resource structs to the table */
+    /**************************************/
+
+    /* If resources in list */
+    if (grs_resource_list_ptr->res_count) {
+        int i;
+
+        /* Allocate memory for resources */
+        grs_resource_list_ptr->res = handle->sn_grs_alloc(grs_resource_list_ptr->res_count * sizeof(sn_grs_resource_s));
+        if (!grs_resource_list_ptr->res) {
+            goto fail;
+        }
+
+        /* Initialise the pointers to NULL to permit easy cleanup */
+        for (i = 0; i < grs_resource_list_ptr->res_count; i++) {
+            grs_resource_list_ptr->res[i].path = NULL;
+            grs_resource_list_ptr->res[i].pathlen = 0;
+        }
+
+        i = 0;
+        ns_list_foreach(sn_nsdl_resource_info_s, grs_resource_ptr, &handle->resource_root_list) {
+            /* Copy pathlen to resource list */
+            grs_resource_list_ptr->res[i].pathlen = grs_resource_ptr->pathlen;
+
+            /* Allocate memory for path string */
+            grs_resource_list_ptr->res[i].path = handle->sn_grs_alloc(grs_resource_list_ptr->res[i].pathlen);
+            if (!grs_resource_list_ptr->res[i].path) {
+                goto fail;
+            }
+
+            /* Copy pathstring to resource list */
+            memcpy(grs_resource_list_ptr->res[i].path, grs_resource_ptr->path, grs_resource_ptr->pathlen);
+
+            i++;
+        }
+    }
+    return grs_resource_list_ptr;
+
+fail:
+    sn_grs_free_resource_list(handle, grs_resource_list_ptr);
+    return NULL;
+}
+
+extern void sn_grs_free_resource_list(struct grs_s *handle, sn_grs_resource_list_s *list)
+{
+    if (!list || !handle) {
+        return;
+    }
+
+    if (list->res) {
+        for (int i = 0; i < list->res_count; i++) {
+            if (list->res[i].path) {
+                handle->sn_grs_free(list->res[i].path);
+                list->res[i].path = NULL;
+            }
+        }
+        handle->sn_grs_free(list->res);
+        list->res = NULL;
+    }
+
+    handle->sn_grs_free(list);
+}
+
+extern const sn_nsdl_resource_info_s *sn_grs_get_first_resource(struct grs_s *handle)
+{
+    if( !handle ){
+        return NULL;
+    }
+    return ns_list_get_first(&handle->resource_root_list);
+}
+
+extern const sn_nsdl_resource_info_s *sn_grs_get_next_resource(struct grs_s *handle, const sn_nsdl_resource_info_s *sn_grs_current_resource)
+{
+    if( !handle || !sn_grs_current_resource ){
+        return NULL;
+    }
+    return ns_list_get_next(&handle->resource_root_list, sn_grs_current_resource);
+}
+
+extern int8_t sn_grs_delete_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path)
+{
+    /* Local variables */
+    sn_nsdl_resource_info_s     *resource_temp  = NULL;
+
+    /* Search if resource found */
+    resource_temp = sn_grs_search_resource(handle, pathlen, path, SN_GRS_SEARCH_METHOD);
+
+    /* If not found */
+    if (resource_temp == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* If found, delete it and delete also subresources, if there is any */
+    do {
+        /* Remove from list */
+        ns_list_remove(&handle->resource_root_list, resource_temp);
+        --handle->resource_root_count;
+
+        /* Free */
+        sn_grs_resource_info_free(handle, resource_temp);
+
+        /* Search for subresources */
+        resource_temp = sn_grs_search_resource(handle, pathlen, path, SN_GRS_DELETE_METHOD);
+    } while (resource_temp != NULL);
+
+    return SN_NSDL_SUCCESS;
+}
+
+extern int8_t sn_grs_update_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res)
+{
+    /* Local variables */
+    sn_nsdl_resource_info_s     *resource_temp  = NULL;
+
+    if( !res || !handle ){
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Search resource */
+    resource_temp = sn_grs_search_resource(handle, res->pathlen, res->path, SN_GRS_SEARCH_METHOD);
+    if (!resource_temp) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* If there is payload on resource, free it */
+    if (resource_temp->resource != NULL) {
+        handle->sn_grs_free(resource_temp->resource);
+        resource_temp->resource = 0;
+    }
+    /* Update resource len */
+    resource_temp->resourcelen = res->resourcelen;
+
+    /* If resource len >0, allocate memory and copy payload */
+    if (res->resourcelen) {
+        resource_temp->resource = handle->sn_grs_alloc(res->resourcelen);
+        if (resource_temp->resource == NULL) {
+
+            resource_temp->resourcelen = 0;
+            return SN_NSDL_FAILURE;
+
+        }
+
+        memcpy(resource_temp->resource, res->resource, resource_temp->resourcelen);
+    }
+
+    /* Update access rights and callback address */
+    resource_temp->access = res->access;
+    resource_temp->sn_grs_dyn_res_callback = res->sn_grs_dyn_res_callback;
+
+    /* TODO: resource_parameters_ptr not copied */
+
+    return SN_NSDL_SUCCESS;
+}
+
+extern int8_t sn_grs_create_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res)
+{
+    if (!res || !handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Check path validity */
+    if (!res->pathlen || !res->path) {
+        return SN_GRS_INVALID_PATH;
+    }
+
+    /* Check if resource already exists */
+    if (sn_grs_search_resource(handle, res->pathlen, res->path, SN_GRS_SEARCH_METHOD) != (sn_nsdl_resource_info_s *)NULL) {
+        return SN_GRS_RESOURCE_ALREADY_EXISTS;
+    }
+
+    if (res->resource_parameters_ptr) {
+        res->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_NOT_REGISTERED;
+    }
+
+    /* Create resource */
+    if (sn_grs_add_resource_to_list(handle, res) == SN_NSDL_SUCCESS) {
+        return SN_NSDL_SUCCESS;
+    }
+    return SN_GRS_LIST_ADDING_FAILURE;
+}
+
+int8_t sn_grs_put_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res)
+{
+    if (!res || !handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Check path validity */
+    if (!res->pathlen || !res->path) {
+        return SN_GRS_INVALID_PATH;
+    }
+
+    /* Check if resource already exists */
+    if (sn_grs_search_resource(handle, res->pathlen, res->path, SN_GRS_SEARCH_METHOD) != (sn_nsdl_resource_info_s *)NULL) {
+        return SN_GRS_RESOURCE_ALREADY_EXISTS;
+    }
+
+    if (res->resource_parameters_ptr) {
+        res->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_NOT_REGISTERED;
+    }
+
+    res->is_put = true;
+
+    ns_list_add_to_start(&handle->resource_root_list, res);
+    ++handle->resource_root_count;
+
+    return SN_NSDL_SUCCESS;
+}
+
+
+/**
+ * \fn  extern int8_t sn_grs_process_coap(uint8_t *packet, uint16_t *packet_len, sn_nsdl_addr_s *src)
+ *
+ * \brief To push CoAP packet to GRS library
+ *
+ *  Used to push an CoAP packet to GRS library for processing.
+ *
+ *  \param  *packet     Pointer to a uint8_t array containing the packet (including the CoAP headers).
+ *                      After successful execution this array may contain the response packet.
+ *
+ *  \param  *packet_len Pointer to length of the packet. After successful execution this array may contain the length
+ *                      of the response packet.
+ *
+ *  \param  *src        Pointer to packet source address information. After successful execution this array may contain
+ *                      the destination address of the response packet.
+ *
+ *  \return             0 = success, -1 = failure
+*/
+extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coap_packet_ptr, sn_nsdl_addr_s *src_addr_ptr)
+{
+    if( !coap_packet_ptr || !nsdl_handle){
+        return SN_NSDL_FAILURE;
+    }
+
+    sn_nsdl_resource_info_s *resource_temp_ptr  = NULL;
+    sn_coap_msg_code_e      status              = COAP_MSG_CODE_EMPTY;
+    sn_coap_hdr_s           *response_message_hdr_ptr = NULL;
+    struct grs_s            *handle = nsdl_handle->grs;
+    bool                    static_get_request = false;
+
+    if (coap_packet_ptr->msg_code <= COAP_MSG_CODE_REQUEST_DELETE) {
+        /* Check if .well-known/core */
+        if (coap_packet_ptr->uri_path_len == WELLKNOWN_PATH_LEN && memcmp(coap_packet_ptr->uri_path_ptr, WELLKNOWN_PATH, WELLKNOWN_PATH_LEN) == 0) {
+            return sn_grs_core_request(nsdl_handle, src_addr_ptr, coap_packet_ptr);
+        }
+
+        /* Get resource */
+        resource_temp_ptr = sn_grs_search_resource(handle, coap_packet_ptr->uri_path_len, coap_packet_ptr->uri_path_ptr, SN_GRS_SEARCH_METHOD);
+
+        /* * * * * * * * * * * */
+        /* If resource exists  */
+        /* * * * * * * * * * * */
+        if (resource_temp_ptr) {
+            /* If dynamic resource, go to callback */
+            if (resource_temp_ptr->mode == SN_GRS_DYNAMIC) {
+                /* Check accesses */
+                if (((coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_GET) && !(resource_temp_ptr->access & SN_GRS_GET_ALLOWED))          ||
+                        ((coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_POST) && !(resource_temp_ptr->access & SN_GRS_POST_ALLOWED))   ||
+                        ((coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_PUT) && !(resource_temp_ptr->access & SN_GRS_PUT_ALLOWED))     ||
+                        ((coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_DELETE) && !(resource_temp_ptr->access & SN_GRS_DELETE_ALLOWED))) {
+
+                    status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
+                } else {
+                    /* Do not call null pointer.. */
+                    if (resource_temp_ptr->sn_grs_dyn_res_callback != NULL) {
+                        resource_temp_ptr->sn_grs_dyn_res_callback(nsdl_handle, coap_packet_ptr, src_addr_ptr, SN_NSDL_PROTOCOL_COAP);
+                    }
+
+                    if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+                        handle->sn_grs_free(coap_packet_ptr->payload_ptr);
+                        coap_packet_ptr->payload_ptr = 0;
+                    }
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, coap_packet_ptr);
+                    return SN_NSDL_SUCCESS;
+                }
+            } else {
+                /* Static resource handling */
+                switch (coap_packet_ptr->msg_code) {
+                    case (COAP_MSG_CODE_REQUEST_GET):
+                        if (resource_temp_ptr->access & SN_GRS_GET_ALLOWED) {
+                            status = COAP_MSG_CODE_RESPONSE_CONTENT;
+                            static_get_request = true;
+                        } else {
+                            status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
+                        }
+                        break;
+                    case (COAP_MSG_CODE_REQUEST_POST):
+                        if (resource_temp_ptr->access & SN_GRS_POST_ALLOWED) {
+                            resource_temp_ptr->resourcelen = coap_packet_ptr->payload_len;
+                            handle->sn_grs_free(resource_temp_ptr->resource);
+                            resource_temp_ptr->resource = 0;
+                            if (resource_temp_ptr->resourcelen) {
+                                resource_temp_ptr->resource = handle->sn_grs_alloc(resource_temp_ptr->resourcelen);
+                                if (!resource_temp_ptr->resource) {
+                                    status = COAP_MSG_CODE_RESPONSE_INTERNAL_SERVER_ERROR;
+                                    break;
+                                }
+                                memcpy(resource_temp_ptr->resource, coap_packet_ptr->payload_ptr, resource_temp_ptr->resourcelen);
+                            }
+                            if (coap_packet_ptr->content_format != COAP_CT_NONE) {
+                                if (resource_temp_ptr->resource_parameters_ptr) {
+                                    resource_temp_ptr->resource_parameters_ptr->coap_content_type = coap_packet_ptr->content_format;
+                                }
+                            }
+                            status = COAP_MSG_CODE_RESPONSE_CHANGED;
+                        } else {
+                            status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
+                        }
+                        break;
+                    case (COAP_MSG_CODE_REQUEST_PUT):
+                        if (resource_temp_ptr->access & SN_GRS_PUT_ALLOWED) {
+                            resource_temp_ptr->resourcelen = coap_packet_ptr->payload_len;
+                            handle->sn_grs_free(resource_temp_ptr->resource);
+                            resource_temp_ptr->resource = 0;
+                            if (resource_temp_ptr->resourcelen) {
+                                resource_temp_ptr->resource = handle->sn_grs_alloc(resource_temp_ptr->resourcelen);
+                                if (!resource_temp_ptr->resource) {
+                                    status = COAP_MSG_CODE_RESPONSE_INTERNAL_SERVER_ERROR;
+                                    break;
+                                }
+                                memcpy(resource_temp_ptr->resource, coap_packet_ptr->payload_ptr, resource_temp_ptr->resourcelen);
+                            }
+                            if (coap_packet_ptr->content_format != COAP_CT_NONE) {
+                                if (resource_temp_ptr->resource_parameters_ptr) {
+                                    resource_temp_ptr->resource_parameters_ptr->coap_content_type = coap_packet_ptr->content_format;
+                                }
+                            }
+                            status = COAP_MSG_CODE_RESPONSE_CHANGED;
+                        } else {
+                            status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
+                        }
+                        break;
+
+                    case (COAP_MSG_CODE_REQUEST_DELETE):
+                        if (resource_temp_ptr->access & SN_GRS_DELETE_ALLOWED) {
+                            if (sn_grs_delete_resource(handle, coap_packet_ptr->uri_path_len, coap_packet_ptr->uri_path_ptr) == SN_NSDL_SUCCESS) {
+                                status = COAP_MSG_CODE_RESPONSE_DELETED;
+                            } else {
+                                //This is dead code (Currently only time delete fails is when resource is not found
+                                //and sn_grs_search_resource is used with same arguments above!)
+                                status = COAP_MSG_CODE_RESPONSE_INTERNAL_SERVER_ERROR;
+                            }
+                        } else {
+                            status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
+                        }
+                        break;
+
+                    default:
+                        status = COAP_MSG_CODE_RESPONSE_FORBIDDEN;
+                        break;
+                }
+            }
+        }
+
+        /* * * * * * * * * * * * * * */
+        /* If resource was not found */
+        /* * * * * * * * * * * * * * */
+
+        else {
+            if (coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_POST) {
+                handle->sn_grs_rx_callback(nsdl_handle, coap_packet_ptr, src_addr_ptr);
+
+                if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+                    handle->sn_grs_free(coap_packet_ptr->payload_ptr);
+                    coap_packet_ptr->payload_ptr = 0;
+                }
+
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, coap_packet_ptr);
+                return SN_NSDL_SUCCESS;
+            } else {
+                status = COAP_MSG_CODE_RESPONSE_NOT_FOUND;
+            }
+        }
+
+    }
+
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+    /* If received packed was other than reset, create response  */
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+    if (coap_packet_ptr->msg_type != COAP_MSG_TYPE_RESET && coap_packet_ptr->msg_type != COAP_MSG_TYPE_ACKNOWLEDGEMENT) {
+
+        /* Allocate resopnse message  */
+        response_message_hdr_ptr = sn_coap_parser_alloc_message(handle->coap);
+        if (!response_message_hdr_ptr) {
+            if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+                handle->sn_grs_free(coap_packet_ptr->payload_ptr);
+                coap_packet_ptr->payload_ptr = 0;
+            }
+            sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, coap_packet_ptr);
+            return SN_NSDL_FAILURE;
+        }
+
+        /* If status has not been defined, response internal server error */
+        if (status == COAP_MSG_CODE_EMPTY) {
+            status = COAP_MSG_CODE_RESPONSE_INTERNAL_SERVER_ERROR;
+        }
+
+        /* Fill header */
+        response_message_hdr_ptr->msg_code = status;
+
+        if (coap_packet_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE) {
+            response_message_hdr_ptr->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+        } else {
+            response_message_hdr_ptr->msg_type = COAP_MSG_TYPE_NON_CONFIRMABLE;
+        }
+
+        response_message_hdr_ptr->msg_id = coap_packet_ptr->msg_id;
+
+        if (coap_packet_ptr->token_ptr) {
+            response_message_hdr_ptr->token_len = coap_packet_ptr->token_len;
+            response_message_hdr_ptr->token_ptr = handle->sn_grs_alloc(response_message_hdr_ptr->token_len);
+            if (!response_message_hdr_ptr->token_ptr) {
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, response_message_hdr_ptr);
+
+                if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+                    handle->sn_grs_free(coap_packet_ptr->payload_ptr);
+                    coap_packet_ptr->payload_ptr = 0;
+                }
+
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, coap_packet_ptr);
+                return SN_NSDL_FAILURE;
+            }
+            memcpy(response_message_hdr_ptr->token_ptr, coap_packet_ptr->token_ptr, response_message_hdr_ptr->token_len);
+        }
+
+        if (status == COAP_MSG_CODE_RESPONSE_CONTENT) {
+            /* Add content type if other than default */
+            if (resource_temp_ptr->resource_parameters_ptr) {
+                /* XXXX Why "if != 0"? 0 means text/plain, and is not the default for CoAP - this prevents setting text/plain? */
+                if (resource_temp_ptr->resource_parameters_ptr->coap_content_type != 0) {
+                    response_message_hdr_ptr->content_format = (sn_coap_content_format_e) resource_temp_ptr->resource_parameters_ptr->coap_content_type;
+                }
+            }
+
+            /* Add payload */
+            if (resource_temp_ptr->resourcelen != 0) {
+                response_message_hdr_ptr->payload_len = resource_temp_ptr->resourcelen;
+                response_message_hdr_ptr->payload_ptr = handle->sn_grs_alloc(response_message_hdr_ptr->payload_len);
+
+                if (!response_message_hdr_ptr->payload_ptr) {
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, response_message_hdr_ptr);
+
+                    if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+                        handle->sn_grs_free(coap_packet_ptr->payload_ptr);
+                        coap_packet_ptr->payload_ptr = 0;
+                    }
+
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, coap_packet_ptr);
+                    return SN_NSDL_FAILURE;
+                }
+
+                memcpy(response_message_hdr_ptr->payload_ptr, resource_temp_ptr->resource, response_message_hdr_ptr->payload_len);
+            }
+            // Add max-age attribute for static resources.
+            // Not a mandatory parameter, no need to return in case of memory allocation fails.
+            if (static_get_request) {
+                if (sn_coap_parser_alloc_options(handle->coap, response_message_hdr_ptr)) {
+                    response_message_hdr_ptr->options_list_ptr->max_age = 0;
+                }
+            }
+        }
+        sn_grs_send_coap_message(nsdl_handle, src_addr_ptr, response_message_hdr_ptr);
+
+        if (response_message_hdr_ptr->payload_ptr) {
+            handle->sn_grs_free(response_message_hdr_ptr->payload_ptr);
+            response_message_hdr_ptr->payload_ptr = 0;
+        }
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, response_message_hdr_ptr);
+    }
+
+    /* Free parsed CoAP message */
+    if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+        handle->sn_grs_free(coap_packet_ptr->payload_ptr);
+        coap_packet_ptr->payload_ptr = 0;
+    }
+    sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, coap_packet_ptr);
+
+
+    return SN_NSDL_SUCCESS;
+}
+
+extern int8_t sn_grs_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *address_ptr, sn_coap_hdr_s *coap_hdr_ptr)
+{
+    tr_debug("sn_grs_send_coap_message");
+    uint8_t     *message_ptr = NULL;
+    uint16_t    message_len = 0;
+    uint8_t     ret_val = 0;
+
+    if( !handle ){
+        return SN_NSDL_FAILURE;
+    }
+
+#if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not used at all, this part of code will not be compiled */
+    ret_val = prepare_blockwise_message(handle->grs->coap, coap_hdr_ptr);
+    if( 0 != ret_val ) {
+        return SN_NSDL_FAILURE;
+    }
+#endif
+
+    /* Calculate message length */
+    message_len = sn_coap_builder_calc_needed_packet_data_size_2(coap_hdr_ptr, handle->grs->coap->sn_coap_block_data_size);
+    tr_debug("sn_grs_send_coap_message - msg len after calc: [%d]", message_len);
+    tr_debug("sn_grs_send_coap_message - msg id: [%d]", coap_hdr_ptr->msg_id);
+
+    /* Allocate memory for message and check was allocating successfully */
+    message_ptr = handle->grs->sn_grs_alloc(message_len);
+    if (message_ptr == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Build CoAP message */
+    if (sn_coap_protocol_build(handle->grs->coap, address_ptr, message_ptr, coap_hdr_ptr, (void *)handle) < 0) {
+        handle->grs->sn_grs_free(message_ptr);
+        message_ptr = 0;
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Call tx callback function to send message */
+    ret_val = handle->grs->sn_grs_tx_callback(handle, SN_NSDL_PROTOCOL_COAP, message_ptr, message_len, address_ptr);
+
+    /* Free allocated memory */
+    handle->grs->sn_grs_free(message_ptr);
+    message_ptr = 0;
+
+    if (ret_val == 0) {
+        return SN_NSDL_FAILURE;
+    } else {
+        return SN_NSDL_SUCCESS;
+    }
+}
+
+static int8_t sn_grs_core_request(struct nsdl_s *handle, sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *coap_packet_ptr)
+{
+    sn_coap_hdr_s           *response_message_hdr_ptr = NULL;
+    sn_coap_content_format_e wellknown_content_format = COAP_CT_LINK_FORMAT;
+
+    /* Allocate response message  */
+    response_message_hdr_ptr = sn_coap_parser_alloc_message(handle->grs->coap);
+    if (response_message_hdr_ptr == NULL) {
+        if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+            handle->grs->sn_grs_free(coap_packet_ptr->payload_ptr);
+            coap_packet_ptr->payload_ptr = 0;
+        }
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Build response */
+    response_message_hdr_ptr->msg_code = COAP_MSG_CODE_RESPONSE_CONTENT;
+    response_message_hdr_ptr->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
+    response_message_hdr_ptr->msg_id = coap_packet_ptr->msg_id;
+    response_message_hdr_ptr->content_format = wellknown_content_format;
+
+    sn_nsdl_build_registration_body(handle, response_message_hdr_ptr, 0);
+
+    /* Send and free */
+    sn_grs_send_coap_message(handle, src_addr_ptr, response_message_hdr_ptr);
+
+    if (response_message_hdr_ptr->payload_ptr) {
+        handle->grs->sn_grs_free(response_message_hdr_ptr->payload_ptr);
+        response_message_hdr_ptr->payload_ptr = 0;
+    }
+    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, response_message_hdr_ptr);
+
+    /* Free parsed CoAP message */
+    if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+        handle->grs->sn_grs_free(coap_packet_ptr->payload_ptr);
+        coap_packet_ptr->payload_ptr = 0;
+    }
+    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+
+    return SN_NSDL_SUCCESS;
+}
+
+/**
+ * \fn  static sn_grs_resource_info_s *sn_grs_search_resource(uint16_t pathlen, uint8_t *path, uint8_t search_method)
+ *
+ * \brief Searches given resource from linked list
+ *
+ *  Search either precise path, or subresources, eg. dr/x -> returns dr/x/1, dr/x/2 etc...
+ *
+ *  \param  pathlen         Length of the path to be search
+ *
+ *  \param  *path           Pointer to the path string to be search
+ *
+ *  \param  search_method   Search method, SEARCH or DELETE
+ *
+ *  \return                 Pointer to the resource. If resource not found, return value is NULL
+ *
+*/
+
+sn_nsdl_resource_info_s *sn_grs_search_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path, uint8_t search_method)
+{
+
+    /* Local variables */
+    uint8_t                     *path_temp_ptr          = NULL;
+    /* Check parameters */
+    if (!handle || !pathlen || !path) {
+        return NULL;
+    }
+
+    /* Remove '/' - marks from the end and beginning */
+    path_temp_ptr = sn_grs_convert_uri(&pathlen, path);
+
+    /* Searchs exact path */
+    if (search_method == SN_GRS_SEARCH_METHOD) {
+        /* Scan all nodes on list */
+        ns_list_foreach(sn_nsdl_resource_info_s, resource_search_temp, &handle->resource_root_list) {
+            /* If length equals.. */
+            if (resource_search_temp->pathlen == pathlen) {
+                /* Compare paths, If same return node pointer*/
+                if (0 == memcmp(resource_search_temp->path, path_temp_ptr, pathlen)) {
+                    return resource_search_temp;
+                }
+            }
+        }
+    }
+    /* Search also subresources, eg. dr/x -> returns dr/x/1, dr/x/2 etc... */
+    else if (search_method == SN_GRS_DELETE_METHOD) {
+        /* Scan all nodes on list */
+        ns_list_foreach(sn_nsdl_resource_info_s, resource_search_temp, &handle->resource_root_list) {
+            uint8_t *temp_path = resource_search_temp->path;
+            if (resource_search_temp->pathlen > pathlen &&
+                    (*(temp_path + (uint8_t)pathlen) == '/') &&
+                    0 == memcmp(resource_search_temp->path, path_temp_ptr, pathlen)) {
+                return resource_search_temp;
+            }
+        }
+    }
+
+    /* If there was not nodes we wanted, return NULL */
+    return NULL;
+}
+
+
+/**
+ * \fn  static int8_t sn_grs_add_resource_to_list(sn_grs_resource_info_s *resource_ptr)
+ *
+ * \brief Adds given resource to resource list
+ *
+ *  \param  *resource_ptr           Pointer to the path string to be search
+ *
+ *  \return 0 = SN_NSDL_SUCCESS, -1 = SN_NSDL_FAILURE
+ *
+*/
+static int8_t sn_grs_add_resource_to_list(struct grs_s *handle, sn_nsdl_resource_info_s *resource_ptr)
+{
+    /* Local variables */
+    uint8_t *path_start_ptr = NULL;
+    uint16_t path_len = 0;
+    sn_nsdl_resource_info_s *resource_copy_ptr = NULL;
+
+    /* Allocate memory for the resource info copy */
+    if (!resource_ptr->pathlen) { //Dead code
+        return SN_NSDL_FAILURE;
+    }
+    resource_copy_ptr = handle->sn_grs_alloc(sizeof(sn_nsdl_resource_info_s));
+    if (resource_copy_ptr == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Set everything to zero  */
+    memset(resource_copy_ptr, 0, sizeof(sn_nsdl_resource_info_s));
+
+    resource_copy_ptr->mode = resource_ptr->mode;
+    resource_copy_ptr->resourcelen = resource_ptr->resourcelen;
+    resource_copy_ptr->sn_grs_dyn_res_callback = resource_ptr->sn_grs_dyn_res_callback;
+    resource_copy_ptr->access = resource_ptr->access;
+    resource_copy_ptr->publish_uri = resource_ptr->publish_uri;
+    resource_copy_ptr->external_memory_block = resource_ptr->external_memory_block;
+
+    /* Remove '/' - chars from the beginning and from the end */
+
+    path_len = resource_ptr->pathlen;
+    path_start_ptr = sn_grs_convert_uri(&path_len, resource_ptr->path);
+
+    /* Allocate memory for the path */
+    resource_copy_ptr->path = handle->sn_grs_alloc(path_len);
+    if (!resource_copy_ptr->path) {
+        sn_grs_resource_info_free(handle, resource_copy_ptr);
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Update pathlen */
+    resource_copy_ptr->pathlen = path_len;
+
+    /* Copy path string to the copy */
+    memcpy(resource_copy_ptr->path, path_start_ptr, resource_copy_ptr->pathlen);
+
+    /* Allocate memory for the resource, and copy it to copy */
+    if (resource_ptr->resource) {
+        resource_copy_ptr->resource = handle->sn_grs_alloc(resource_ptr->resourcelen);
+        if (!resource_copy_ptr->resource) {
+            sn_grs_resource_info_free(handle, resource_copy_ptr);
+            return SN_NSDL_FAILURE;
+        }
+        memcpy(resource_copy_ptr->resource, resource_ptr->resource, resource_ptr->resourcelen);
+    }
+
+
+
+    /* If resource parameters exists, copy them */
+    if (resource_ptr->resource_parameters_ptr) {
+        resource_copy_ptr->resource_parameters_ptr = handle->sn_grs_alloc(sizeof(sn_nsdl_resource_parameters_s));
+        if (!resource_copy_ptr->resource_parameters_ptr) {
+            sn_grs_resource_info_free(handle, resource_copy_ptr);
+            return SN_NSDL_FAILURE;
+        }
+
+        memset(resource_copy_ptr->resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
+
+        resource_copy_ptr->resource_parameters_ptr->resource_type_len = resource_ptr->resource_parameters_ptr->resource_type_len;
+
+//        resource_copy_ptr->resource_parameters_ptr->mime_content_type = resource_ptr->resource_parameters_ptr->mime_content_type;
+
+        resource_copy_ptr->resource_parameters_ptr->observable = resource_ptr->resource_parameters_ptr->observable;
+
+        if (resource_ptr->resource_parameters_ptr->resource_type_ptr) {
+            resource_copy_ptr->resource_parameters_ptr->resource_type_ptr = handle->sn_grs_alloc(resource_ptr->resource_parameters_ptr->resource_type_len);
+            if (!resource_copy_ptr->resource_parameters_ptr->resource_type_ptr) {
+                sn_grs_resource_info_free(handle, resource_copy_ptr);
+                return SN_NSDL_FAILURE;
+            }
+            memcpy(resource_copy_ptr->resource_parameters_ptr->resource_type_ptr, resource_ptr->resource_parameters_ptr->resource_type_ptr, resource_ptr->resource_parameters_ptr->resource_type_len);
+        }
+
+        resource_copy_ptr->resource_parameters_ptr->interface_description_len = resource_ptr->resource_parameters_ptr->interface_description_len;
+
+        if (resource_ptr->resource_parameters_ptr->interface_description_ptr) {
+            resource_copy_ptr->resource_parameters_ptr->interface_description_ptr = handle->sn_grs_alloc(resource_ptr->resource_parameters_ptr->interface_description_len);
+            if (!resource_copy_ptr->resource_parameters_ptr->interface_description_ptr) {
+                sn_grs_resource_info_free(handle, resource_copy_ptr);
+                return SN_NSDL_FAILURE;
+            }
+            memcpy(resource_copy_ptr->resource_parameters_ptr->interface_description_ptr, resource_ptr->resource_parameters_ptr->interface_description_ptr, resource_ptr->resource_parameters_ptr->interface_description_len);
+        }
+
+        /* Copy auto observation parameter */
+        /* todo: aobs not supported ATM - needs fixing */
+        /*      if(resource_ptr->resource_parameters_ptr->auto_obs_ptr && resource_ptr->resource_parameters_ptr->auto_obs_len)
+                {
+                    resource_copy_ptr->resource_parameters_ptr->auto_obs_ptr = sn_grs_alloc(resource_ptr->resource_parameters_ptr->auto_obs_len);
+                    if(!resource_copy_ptr->resource_parameters_ptr->auto_obs_ptr)
+                    {
+                        sn_grs_resource_info_free(resource_copy_ptr);
+                        return SN_NSDL_FAILURE;
+                    }
+                    memcpy(resource_copy_ptr->resource_parameters_ptr->auto_obs_ptr, resource_ptr->resource_parameters_ptr->auto_obs_ptr, resource_ptr->resource_parameters_ptr->auto_obs_len);
+                    resource_copy_ptr->resource_parameters_ptr->auto_obs_len = resource_ptr->resource_parameters_ptr->auto_obs_len;
+                }
+
+                resource_copy_ptr->resource_parameters_ptr->coap_content_type = resource_ptr->resource_parameters_ptr->coap_content_type;
+                */
+    }
+
+    /* Add copied resource to the linked list */
+    ns_list_add_to_start(&handle->resource_root_list, resource_copy_ptr);
+    ++handle->resource_root_count;
+
+    return SN_NSDL_SUCCESS;
+}
+
+
+/**
+ * \fn  static uint8_t *sn_grs_convert_uri(uint16_t *uri_len, uint8_t *uri_ptr)
+ *
+ * \brief Removes '/' from the beginning and from the end of uri string
+ *
+ *  \param  *uri_len            Pointer to the length of the path string
+ *
+ *  \param  *uri_ptr            Pointer to the path string
+ *
+ *  \return start pointer of the uri
+ *
+*/
+
+static uint8_t *sn_grs_convert_uri(uint16_t *uri_len, uint8_t *uri_ptr)
+{
+    /* Local variables */
+    uint8_t *uri_start_ptr = uri_ptr;
+
+    /* If '/' in the beginning, update uri start pointer and uri len */
+    if (*uri_ptr == '/') {
+        uri_start_ptr = uri_ptr + 1;
+        *uri_len = *uri_len - 1;
+    }
+
+    /* If '/' at the end, update uri len */
+    if (*(uri_start_ptr + *uri_len - 1) == '/') {
+        *uri_len = *uri_len - 1;
+    }
+
+    /* Return start pointer */
+    return uri_start_ptr;
+}
+
+/**
+ * \fn  static int8_t sn_grs_resource_info_free(sn_grs_resource_info_s *resource_ptr)
+ *
+ * \brief Frees resource info structure
+ *
+ *  \param *resource_ptr    Pointer to the resource
+ *
+ *  \return 0 if success, -1 if failed
+ *
+*/
+static int8_t sn_grs_resource_info_free(struct grs_s *handle, sn_nsdl_resource_info_s *resource_ptr)
+{
+    if (resource_ptr) {
+        if (resource_ptr->resource_parameters_ptr) {
+            if (!resource_ptr->is_put) {
+                if (resource_ptr->resource_parameters_ptr->interface_description_ptr) {
+                    handle->sn_grs_free(resource_ptr->resource_parameters_ptr->interface_description_ptr);
+                    resource_ptr->resource_parameters_ptr->interface_description_ptr = 0;
+                }
+
+                if (resource_ptr->resource_parameters_ptr->resource_type_ptr) {
+                    handle->sn_grs_free(resource_ptr->resource_parameters_ptr->resource_type_ptr);
+                    resource_ptr->resource_parameters_ptr->resource_type_ptr = 0;
+                }
+            }
+
+            /* Todo: aobs not supported ATM - needs fixing */
+            /*
+            if(resource_ptr->resource_parameters_ptr->auto_obs_ptr)
+            {
+                sn_grs_free(resource_ptr->resource_parameters_ptr->auto_obs_ptr);
+                resource_ptr->resource_parameters_ptr->auto_obs_ptr = 0;
+            }
+            */
+
+            handle->sn_grs_free(resource_ptr->resource_parameters_ptr);
+            resource_ptr->resource_parameters_ptr = 0;
+        }
+
+        if (!resource_ptr->is_put) {
+            if (resource_ptr->path) {
+                handle->sn_grs_free(resource_ptr->path);
+                resource_ptr->path = 0;
+            }
+            if (resource_ptr->resource) {
+                handle->sn_grs_free(resource_ptr->resource);
+                resource_ptr->resource = 0;
+            }
+        }
+        handle->sn_grs_free(resource_ptr);
+
+        return SN_NSDL_SUCCESS;
+    }
+    return SN_NSDL_FAILURE; //Dead code?
+}
+
+void sn_grs_mark_resources_as_registered(struct nsdl_s *handle)
+{
+    if( !handle ){
+        return;
+    }
+
+    const sn_nsdl_resource_info_s *temp_resource;
+
+    temp_resource = sn_grs_get_first_resource(handle->grs);
+
+    while (temp_resource) {
+        if (temp_resource->resource_parameters_ptr) {
+            if (temp_resource->resource_parameters_ptr->registered == SN_NDSL_RESOURCE_REGISTERING) {
+                temp_resource->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_REGISTERED;
+            }
+        }
+        temp_resource = sn_grs_get_next_resource(handle->grs, temp_resource);
+    }
+}

--- a/source/libNsdl/src/sn_grs2.c
+++ b/source/libNsdl/src/sn_grs2.c
@@ -23,7 +23,6 @@
  */
 #include <string.h>
 #include <stdlib.h>
-
 #include "ns_list.h"
 #include "ns_types.h"
 #include "sn_nsdl.h"
@@ -40,9 +39,11 @@
 #define WELLKNOWN_PATH                  (".well-known/core")
 
 /* Local static function prototypes */
-static int8_t                       sn_grs_resource_info_free(struct grs_s *handle, sn_nsdl_resource_info_s *resource_ptr);
+static int8_t                       sn_grs_resource_info_free(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *resource_ptr);
 static uint8_t                     *sn_grs_convert_uri(uint16_t *uri_len, uint8_t *uri_ptr);
-static int8_t                       sn_grs_add_resource_to_list(struct grs_s *handle, sn_nsdl_resource_info_s *resource_ptr);
+#ifndef MEMORY_OPTIMIZED_API
+static int8_t                       sn_grs_add_resource_to_list(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *resource_ptr);
+#endif
 static int8_t                       sn_grs_core_request(struct nsdl_s *handle, sn_nsdl_addr_s *src_addr_ptr, sn_coap_hdr_s *coap_packet_ptr);
 static uint8_t                      coap_tx_callback(uint8_t *, uint16_t, sn_nsdl_addr_s *, void *);
 static int8_t                       coap_rx_callback(sn_coap_hdr_s *coap_ptr, sn_nsdl_addr_s *address_ptr, void *param);
@@ -60,7 +61,7 @@ extern int8_t sn_grs_destroy(struct grs_s *handle)
     if( handle == NULL ){
         return 0;
     }
-    ns_list_foreach_safe(sn_nsdl_resource_info_s, tmp, &handle->resource_root_list) {
+    ns_list_foreach_safe(sn_nsdl_dynamic_resource_parameters_s, tmp, &handle->resource_root_list) {
         ns_list_remove(&handle->resource_root_list, tmp);
         --handle->resource_root_count;
         sn_grs_resource_info_free(handle, tmp);
@@ -143,7 +144,6 @@ extern struct grs_s *sn_grs_init(uint8_t (*sn_grs_tx_callback_ptr)(struct nsdl_s
     return handle_ptr;
 }
 
-
 extern sn_grs_resource_list_s *sn_grs_list_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path)
 {
     (void) pathlen;
@@ -184,9 +184,9 @@ extern sn_grs_resource_list_s *sn_grs_list_resource(struct grs_s *handle, uint16
         }
 
         i = 0;
-        ns_list_foreach(sn_nsdl_resource_info_s, grs_resource_ptr, &handle->resource_root_list) {
+        ns_list_foreach(sn_nsdl_dynamic_resource_parameters_s, grs_resource_ptr, &handle->resource_root_list) {
             /* Copy pathlen to resource list */
-            grs_resource_list_ptr->res[i].pathlen = grs_resource_ptr->pathlen;
+            grs_resource_list_ptr->res[i].pathlen = grs_resource_ptr->static_resource_parameters->pathlen;
 
             /* Allocate memory for path string */
             grs_resource_list_ptr->res[i].path = handle->sn_grs_alloc(grs_resource_list_ptr->res[i].pathlen);
@@ -195,7 +195,9 @@ extern sn_grs_resource_list_s *sn_grs_list_resource(struct grs_s *handle, uint16
             }
 
             /* Copy pathstring to resource list */
-            memcpy(grs_resource_list_ptr->res[i].path, grs_resource_ptr->path, grs_resource_ptr->pathlen);
+            memcpy(grs_resource_list_ptr->res[i].path,
+                   grs_resource_ptr->static_resource_parameters->path,
+                   grs_resource_ptr->static_resource_parameters->pathlen);
 
             i++;
         }
@@ -227,7 +229,7 @@ extern void sn_grs_free_resource_list(struct grs_s *handle, sn_grs_resource_list
     handle->sn_grs_free(list);
 }
 
-extern const sn_nsdl_resource_info_s *sn_grs_get_first_resource(struct grs_s *handle)
+extern sn_nsdl_dynamic_resource_parameters_s *sn_grs_get_first_resource(struct grs_s *handle)
 {
     if( !handle ){
         return NULL;
@@ -235,7 +237,8 @@ extern const sn_nsdl_resource_info_s *sn_grs_get_first_resource(struct grs_s *ha
     return ns_list_get_first(&handle->resource_root_list);
 }
 
-extern const sn_nsdl_resource_info_s *sn_grs_get_next_resource(struct grs_s *handle, const sn_nsdl_resource_info_s *sn_grs_current_resource)
+extern sn_nsdl_dynamic_resource_parameters_s *sn_grs_get_next_resource(struct grs_s *handle,
+                                                                             const sn_nsdl_dynamic_resource_parameters_s *sn_grs_current_resource)
 {
     if( !handle || !sn_grs_current_resource ){
         return NULL;
@@ -246,7 +249,7 @@ extern const sn_nsdl_resource_info_s *sn_grs_get_next_resource(struct grs_s *han
 extern int8_t sn_grs_delete_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path)
 {
     /* Local variables */
-    sn_nsdl_resource_info_s     *resource_temp  = NULL;
+    sn_nsdl_dynamic_resource_parameters_s     *resource_temp  = NULL;
 
     /* Search if resource found */
     resource_temp = sn_grs_search_resource(handle, pathlen, path, SN_GRS_SEARCH_METHOD);
@@ -272,40 +275,46 @@ extern int8_t sn_grs_delete_resource(struct grs_s *handle, uint16_t pathlen, uin
     return SN_NSDL_SUCCESS;
 }
 
-extern int8_t sn_grs_update_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res)
+#ifndef MEMORY_OPTIMIZED_API
+extern int8_t sn_grs_update_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
 {
     /* Local variables */
-    sn_nsdl_resource_info_s     *resource_temp  = NULL;
+    sn_nsdl_dynamic_resource_parameters_s     *resource_temp  = NULL;
 
     if( !res || !handle ){
         return SN_NSDL_FAILURE;
     }
 
     /* Search resource */
-    resource_temp = sn_grs_search_resource(handle, res->pathlen, res->path, SN_GRS_SEARCH_METHOD);
+    resource_temp = sn_grs_search_resource(handle,
+                                           res->static_resource_parameters->pathlen,
+                                           res->static_resource_parameters->path,
+                                           SN_GRS_SEARCH_METHOD);
     if (!resource_temp) {
         return SN_NSDL_FAILURE;
     }
 
     /* If there is payload on resource, free it */
-    if (resource_temp->resource != NULL) {
-        handle->sn_grs_free(resource_temp->resource);
-        resource_temp->resource = 0;
+    if (resource_temp->static_resource_parameters->resource != NULL) {
+        handle->sn_grs_free(resource_temp->static_resource_parameters->resource);
+        resource_temp->static_resource_parameters->resource = 0;
     }
     /* Update resource len */
-    resource_temp->resourcelen = res->resourcelen;
+    resource_temp->static_resource_parameters->resourcelen =
+            res->static_resource_parameters->resourcelen;
 
     /* If resource len >0, allocate memory and copy payload */
-    if (res->resourcelen) {
-        resource_temp->resource = handle->sn_grs_alloc(res->resourcelen);
-        if (resource_temp->resource == NULL) {
-
-            resource_temp->resourcelen = 0;
+    if (res->static_resource_parameters->resourcelen) {
+        resource_temp->static_resource_parameters->resource =
+                handle->sn_grs_alloc(res->static_resource_parameters->resourcelen);
+        if (resource_temp->static_resource_parameters->resource == NULL) {
+            resource_temp->static_resource_parameters->resourcelen = 0;
             return SN_NSDL_FAILURE;
-
         }
 
-        memcpy(resource_temp->resource, res->resource, resource_temp->resourcelen);
+        memcpy(resource_temp->static_resource_parameters->resource,
+               res->static_resource_parameters->resource,
+               resource_temp->static_resource_parameters->resourcelen);
     }
 
     /* Update access rights and callback address */
@@ -317,24 +326,28 @@ extern int8_t sn_grs_update_resource(struct grs_s *handle, sn_nsdl_resource_info
     return SN_NSDL_SUCCESS;
 }
 
-extern int8_t sn_grs_create_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res)
+extern int8_t sn_grs_create_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
 {
     if (!res || !handle) {
         return SN_NSDL_FAILURE;
     }
 
     /* Check path validity */
-    if (!res->pathlen || !res->path) {
+    if (!res->static_resource_parameters->pathlen || !res->static_resource_parameters->path) {
         return SN_GRS_INVALID_PATH;
     }
 
     /* Check if resource already exists */
-    if (sn_grs_search_resource(handle, res->pathlen, res->path, SN_GRS_SEARCH_METHOD) != (sn_nsdl_resource_info_s *)NULL) {
+    if (sn_grs_search_resource(handle,
+                               res->static_resource_parameters->pathlen,
+                               res->static_resource_parameters->path,
+                               SN_GRS_SEARCH_METHOD) !=
+            (sn_nsdl_dynamic_resource_parameters_s *)NULL) {
         return SN_GRS_RESOURCE_ALREADY_EXISTS;
     }
 
-    if (res->resource_parameters_ptr) {
-        res->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_NOT_REGISTERED;
+    if (res) {
+        res->registered = SN_NDSL_RESOURCE_NOT_REGISTERED;
     }
 
     /* Create resource */
@@ -344,27 +357,152 @@ extern int8_t sn_grs_create_resource(struct grs_s *handle, sn_nsdl_resource_info
     return SN_GRS_LIST_ADDING_FAILURE;
 }
 
-int8_t sn_grs_put_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res)
+/**
+ * \fn  static int8_t sn_grs_add_resource_to_list(sn_nsdl_dynamic_resource_parameters_s *resource_ptr)
+ *
+ * \brief Adds given resource to resource list
+ *
+ *  \param  *resource_ptr           Pointer to the path string to be search
+ *
+ *  \return 0 = SN_NSDL_SUCCESS, -1 = SN_NSDL_FAILURE
+ *
+*/
+static int8_t sn_grs_add_resource_to_list(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *resource_ptr)
+{
+    /* Local variables */
+
+    uint8_t *path_start_ptr = NULL;
+    uint16_t path_len = 0;
+    sn_nsdl_dynamic_resource_parameters_s *resource_copy_ptr = NULL;
+
+    /* Allocate memory for the resource info copy */
+    if (!resource_ptr->static_resource_parameters->pathlen) { //Dead code
+        return SN_NSDL_FAILURE;
+    }
+
+    resource_copy_ptr = handle->sn_grs_alloc(sizeof(sn_nsdl_dynamic_resource_parameters_s));
+    if (resource_copy_ptr == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Set everything to zero  */
+    memset(resource_copy_ptr, 0, sizeof(sn_nsdl_dynamic_resource_parameters_s));
+    resource_copy_ptr->sn_grs_dyn_res_callback = resource_ptr->sn_grs_dyn_res_callback;
+    resource_copy_ptr->publish_uri = resource_ptr->publish_uri;
+    resource_copy_ptr->free_on_delete = resource_ptr->free_on_delete;
+    resource_copy_ptr->coap_content_type = resource_ptr->coap_content_type;
+    resource_copy_ptr->observable = resource_ptr->observable;
+    resource_copy_ptr->access = resource_ptr->access;
+    /* If resource parameters exists, copy them */
+    if (resource_ptr->static_resource_parameters) {
+        resource_copy_ptr->static_resource_parameters = handle->sn_grs_alloc(sizeof(sn_nsdl_static_resource_parameters_s));
+        if (!resource_copy_ptr->static_resource_parameters) {
+            sn_grs_resource_info_free(handle, resource_copy_ptr);
+            return SN_NSDL_FAILURE;
+        }
+
+        memset(resource_copy_ptr->static_resource_parameters, 0, sizeof(sn_nsdl_static_resource_parameters_s));
+        resource_copy_ptr->static_resource_parameters->mode =
+                resource_ptr->static_resource_parameters->mode;
+        resource_copy_ptr->static_resource_parameters->external_memory_block =
+                resource_ptr->static_resource_parameters->external_memory_block;
+        resource_copy_ptr->static_resource_parameters->free_on_delete =
+                resource_ptr->static_resource_parameters->free_on_delete;
+
+        resource_copy_ptr->static_resource_parameters->pathlen =
+                resource_ptr->static_resource_parameters->pathlen;
+        resource_copy_ptr->static_resource_parameters->resourcelen =
+                resource_ptr->static_resource_parameters->resourcelen;
+
+        if (resource_ptr->static_resource_parameters->resource_type_ptr) {
+            // alloc space for terminating zero too
+            const size_t resource_type_len = strlen(resource_ptr->static_resource_parameters->resource_type_ptr) + 1;
+            resource_copy_ptr->static_resource_parameters->resource_type_ptr =
+                    handle->sn_grs_alloc(resource_type_len);
+            if (!resource_copy_ptr->static_resource_parameters->resource_type_ptr) {
+                sn_grs_resource_info_free(handle, resource_copy_ptr);
+                return SN_NSDL_FAILURE;
+            }
+            memcpy(resource_copy_ptr->static_resource_parameters->resource_type_ptr,
+                   resource_ptr->static_resource_parameters->resource_type_ptr,
+                   resource_type_len);
+        }
+
+        if (resource_ptr->static_resource_parameters->interface_description_ptr) {
+            // todo: a sn_grs_strdup() or similar helper to avoid this copy-paste pattern.
+            const size_t interface_description_len = strlen(resource_ptr->static_resource_parameters->interface_description_ptr) + 1;
+            resource_copy_ptr->static_resource_parameters->interface_description_ptr =
+                    handle->sn_grs_alloc(interface_description_len);
+            if (!resource_copy_ptr->static_resource_parameters->interface_description_ptr) {
+                sn_grs_resource_info_free(handle, resource_copy_ptr);
+                return SN_NSDL_FAILURE;
+            }
+            memcpy(resource_copy_ptr->static_resource_parameters->interface_description_ptr,
+                   resource_ptr->static_resource_parameters->interface_description_ptr,
+                   interface_description_len);
+        }
+
+        /* Remove '/' - chars from the beginning and from the end */
+
+        path_len = resource_ptr->static_resource_parameters->pathlen;
+        path_start_ptr = sn_grs_convert_uri(&path_len, resource_ptr->static_resource_parameters->path);
+
+        /* Allocate memory for the path */
+        resource_copy_ptr->static_resource_parameters->path = handle->sn_grs_alloc(path_len);
+        if (!resource_copy_ptr->static_resource_parameters->path) {
+            sn_grs_resource_info_free(handle, resource_copy_ptr);
+            return SN_NSDL_FAILURE;
+        }
+
+        /* Update pathlen */
+        resource_copy_ptr->static_resource_parameters->pathlen = path_len;
+
+        /* Copy path string to the copy */
+        memcpy(resource_copy_ptr->static_resource_parameters->path,
+               path_start_ptr,
+               resource_copy_ptr->static_resource_parameters->pathlen);
+
+        /* Allocate memory for the resource, and copy it to copy */
+        if (resource_ptr->static_resource_parameters->resource) {
+            resource_copy_ptr->static_resource_parameters->resource =
+                    handle->sn_grs_alloc(resource_ptr->static_resource_parameters->resourcelen);
+            if (!resource_copy_ptr->static_resource_parameters->resource) {
+                sn_grs_resource_info_free(handle, resource_copy_ptr);
+                return SN_NSDL_FAILURE;
+            }
+            memcpy(resource_copy_ptr->static_resource_parameters->resource,
+                   resource_ptr->static_resource_parameters->resource,
+                   resource_ptr->static_resource_parameters->resourcelen);
+        }
+    }
+
+    /* Add copied resource to the linked list */
+    ns_list_add_to_start(&handle->resource_root_list, resource_copy_ptr);
+    ++handle->resource_root_count;
+
+    return SN_NSDL_SUCCESS;
+}
+#endif
+
+int8_t sn_grs_put_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
 {
     if (!res || !handle) {
         return SN_NSDL_FAILURE;
     }
 
     /* Check path validity */
-    if (!res->pathlen || !res->path) {
+    if (!res->static_resource_parameters->pathlen || !res->static_resource_parameters->path) {
         return SN_GRS_INVALID_PATH;
     }
 
     /* Check if resource already exists */
-    if (sn_grs_search_resource(handle, res->pathlen, res->path, SN_GRS_SEARCH_METHOD) != (sn_nsdl_resource_info_s *)NULL) {
+    if (sn_grs_search_resource(handle,
+                               res->static_resource_parameters->pathlen,
+                               res->static_resource_parameters->path, SN_GRS_SEARCH_METHOD) != (sn_nsdl_dynamic_resource_parameters_s *)NULL) {
         return SN_GRS_RESOURCE_ALREADY_EXISTS;
     }
 
-    if (res->resource_parameters_ptr) {
-        res->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_NOT_REGISTERED;
-    }
-
-    res->is_put = true;
+    res->registered = SN_NDSL_RESOURCE_NOT_REGISTERED;
 
     ns_list_add_to_start(&handle->resource_root_list, res);
     ++handle->resource_root_count;
@@ -372,6 +510,29 @@ int8_t sn_grs_put_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res)
     return SN_NSDL_SUCCESS;
 }
 
+int8_t sn_grs_pop_resource(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
+{
+    if (!res || !handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Check path validity */
+    if (!res->static_resource_parameters->pathlen || !res->static_resource_parameters->path) {
+        return SN_GRS_INVALID_PATH;
+    }
+
+    /* Check if resource exists on list. */
+    if (sn_grs_search_resource(handle,
+                               res->static_resource_parameters->pathlen,
+                               res->static_resource_parameters->path, SN_GRS_SEARCH_METHOD) == (sn_nsdl_dynamic_resource_parameters_s *)NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    ns_list_remove(&handle->resource_root_list, res);
+    --handle->resource_root_count;
+
+    return SN_NSDL_SUCCESS;
+}
 
 /**
  * \fn  extern int8_t sn_grs_process_coap(uint8_t *packet, uint16_t *packet_len, sn_nsdl_addr_s *src)
@@ -393,11 +554,17 @@ int8_t sn_grs_put_resource(struct grs_s *handle, sn_nsdl_resource_info_s *res)
 */
 extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coap_packet_ptr, sn_nsdl_addr_s *src_addr_ptr)
 {
+    tr_debug("sn_grs_process_coap");
     if( !coap_packet_ptr || !nsdl_handle){
         return SN_NSDL_FAILURE;
     }
 
-    sn_nsdl_resource_info_s *resource_temp_ptr  = NULL;
+    tr_debug("sn_grs_process_coap - coap params:");
+    tr_debug("msg code: (%d), msg type: (%d), msg id: (%d), path: (%.*s)",
+             coap_packet_ptr->msg_code, coap_packet_ptr->msg_type, coap_packet_ptr->msg_id,
+             coap_packet_ptr->uri_path_len, coap_packet_ptr->uri_path_ptr);
+
+    sn_nsdl_dynamic_resource_parameters_s *resource_temp_ptr  = NULL;
     sn_coap_msg_code_e      status              = COAP_MSG_CODE_EMPTY;
     sn_coap_hdr_s           *response_message_hdr_ptr = NULL;
     struct grs_s            *handle = nsdl_handle->grs;
@@ -412,18 +579,20 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
         /* Get resource */
         resource_temp_ptr = sn_grs_search_resource(handle, coap_packet_ptr->uri_path_len, coap_packet_ptr->uri_path_ptr, SN_GRS_SEARCH_METHOD);
 
+
         /* * * * * * * * * * * */
         /* If resource exists  */
         /* * * * * * * * * * * */
         if (resource_temp_ptr) {
+            tr_debug("sn_grs_process_coap - found (%.*s)", resource_temp_ptr->static_resource_parameters->pathlen,
+                     resource_temp_ptr->static_resource_parameters->path);
             /* If dynamic resource, go to callback */
-            if (resource_temp_ptr->mode == SN_GRS_DYNAMIC) {
+            if (resource_temp_ptr->static_resource_parameters->mode == SN_GRS_DYNAMIC) {
                 /* Check accesses */
                 if (((coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_GET) && !(resource_temp_ptr->access & SN_GRS_GET_ALLOWED))          ||
                         ((coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_POST) && !(resource_temp_ptr->access & SN_GRS_POST_ALLOWED))   ||
                         ((coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_PUT) && !(resource_temp_ptr->access & SN_GRS_PUT_ALLOWED))     ||
                         ((coap_packet_ptr->msg_code == COAP_MSG_CODE_REQUEST_DELETE) && !(resource_temp_ptr->access & SN_GRS_DELETE_ALLOWED))) {
-
                     status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
                 } else {
                     /* Do not call null pointer.. */
@@ -441,7 +610,7 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
             } else {
                 /* Static resource handling */
                 switch (coap_packet_ptr->msg_code) {
-                    case (COAP_MSG_CODE_REQUEST_GET):
+                    case COAP_MSG_CODE_REQUEST_GET:
                         if (resource_temp_ptr->access & SN_GRS_GET_ALLOWED) {
                             status = COAP_MSG_CODE_RESPONSE_CONTENT;
                             static_get_request = true;
@@ -449,65 +618,11 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
                             status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
                         }
                         break;
-                    case (COAP_MSG_CODE_REQUEST_POST):
-                        if (resource_temp_ptr->access & SN_GRS_POST_ALLOWED) {
-                            resource_temp_ptr->resourcelen = coap_packet_ptr->payload_len;
-                            handle->sn_grs_free(resource_temp_ptr->resource);
-                            resource_temp_ptr->resource = 0;
-                            if (resource_temp_ptr->resourcelen) {
-                                resource_temp_ptr->resource = handle->sn_grs_alloc(resource_temp_ptr->resourcelen);
-                                if (!resource_temp_ptr->resource) {
-                                    status = COAP_MSG_CODE_RESPONSE_INTERNAL_SERVER_ERROR;
-                                    break;
-                                }
-                                memcpy(resource_temp_ptr->resource, coap_packet_ptr->payload_ptr, resource_temp_ptr->resourcelen);
-                            }
-                            if (coap_packet_ptr->content_format != COAP_CT_NONE) {
-                                if (resource_temp_ptr->resource_parameters_ptr) {
-                                    resource_temp_ptr->resource_parameters_ptr->coap_content_type = coap_packet_ptr->content_format;
-                                }
-                            }
-                            status = COAP_MSG_CODE_RESPONSE_CHANGED;
-                        } else {
-                            status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
-                        }
-                        break;
-                    case (COAP_MSG_CODE_REQUEST_PUT):
-                        if (resource_temp_ptr->access & SN_GRS_PUT_ALLOWED) {
-                            resource_temp_ptr->resourcelen = coap_packet_ptr->payload_len;
-                            handle->sn_grs_free(resource_temp_ptr->resource);
-                            resource_temp_ptr->resource = 0;
-                            if (resource_temp_ptr->resourcelen) {
-                                resource_temp_ptr->resource = handle->sn_grs_alloc(resource_temp_ptr->resourcelen);
-                                if (!resource_temp_ptr->resource) {
-                                    status = COAP_MSG_CODE_RESPONSE_INTERNAL_SERVER_ERROR;
-                                    break;
-                                }
-                                memcpy(resource_temp_ptr->resource, coap_packet_ptr->payload_ptr, resource_temp_ptr->resourcelen);
-                            }
-                            if (coap_packet_ptr->content_format != COAP_CT_NONE) {
-                                if (resource_temp_ptr->resource_parameters_ptr) {
-                                    resource_temp_ptr->resource_parameters_ptr->coap_content_type = coap_packet_ptr->content_format;
-                                }
-                            }
-                            status = COAP_MSG_CODE_RESPONSE_CHANGED;
-                        } else {
-                            status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
-                        }
-                        break;
 
-                    case (COAP_MSG_CODE_REQUEST_DELETE):
-                        if (resource_temp_ptr->access & SN_GRS_DELETE_ALLOWED) {
-                            if (sn_grs_delete_resource(handle, coap_packet_ptr->uri_path_len, coap_packet_ptr->uri_path_ptr) == SN_NSDL_SUCCESS) {
-                                status = COAP_MSG_CODE_RESPONSE_DELETED;
-                            } else {
-                                //This is dead code (Currently only time delete fails is when resource is not found
-                                //and sn_grs_search_resource is used with same arguments above!)
-                                status = COAP_MSG_CODE_RESPONSE_INTERNAL_SERVER_ERROR;
-                            }
-                        } else {
-                            status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
-                        }
+                    case COAP_MSG_CODE_REQUEST_POST:
+                    case COAP_MSG_CODE_REQUEST_PUT:
+                    case COAP_MSG_CODE_REQUEST_DELETE:
+                        status = COAP_MSG_CODE_RESPONSE_METHOD_NOT_ALLOWED;
                         break;
 
                     default:
@@ -536,9 +651,7 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
                 status = COAP_MSG_CODE_RESPONSE_NOT_FOUND;
             }
         }
-
     }
-
 
     /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
     /* If received packed was other than reset, create response  */
@@ -591,16 +704,17 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
 
         if (status == COAP_MSG_CODE_RESPONSE_CONTENT) {
             /* Add content type if other than default */
-            if (resource_temp_ptr->resource_parameters_ptr) {
+            if (resource_temp_ptr->static_resource_parameters) {
                 /* XXXX Why "if != 0"? 0 means text/plain, and is not the default for CoAP - this prevents setting text/plain? */
-                if (resource_temp_ptr->resource_parameters_ptr->coap_content_type != 0) {
-                    response_message_hdr_ptr->content_format = (sn_coap_content_format_e) resource_temp_ptr->resource_parameters_ptr->coap_content_type;
+                if (resource_temp_ptr->coap_content_type != 0) {
+                    response_message_hdr_ptr->content_format =
+                            (sn_coap_content_format_e) resource_temp_ptr->coap_content_type;
                 }
             }
 
             /* Add payload */
-            if (resource_temp_ptr->resourcelen != 0) {
-                response_message_hdr_ptr->payload_len = resource_temp_ptr->resourcelen;
+            if (resource_temp_ptr->static_resource_parameters->resourcelen != 0) {
+                response_message_hdr_ptr->payload_len = resource_temp_ptr->static_resource_parameters->resourcelen;
                 response_message_hdr_ptr->payload_ptr = handle->sn_grs_alloc(response_message_hdr_ptr->payload_len);
 
                 if (!response_message_hdr_ptr->payload_ptr) {
@@ -615,7 +729,9 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
                     return SN_NSDL_FAILURE;
                 }
 
-                memcpy(response_message_hdr_ptr->payload_ptr, resource_temp_ptr->resource, response_message_hdr_ptr->payload_len);
+                memcpy(response_message_hdr_ptr->payload_ptr,
+                       resource_temp_ptr->static_resource_parameters->resource,
+                       response_message_hdr_ptr->payload_len);
             }
             // Add max-age attribute for static resources.
             // Not a mandatory parameter, no need to return in case of memory allocation fails.
@@ -640,7 +756,6 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
         coap_packet_ptr->payload_ptr = 0;
     }
     sn_coap_parser_release_allocated_coap_msg_mem(handle->coap, coap_packet_ptr);
-
 
     return SN_NSDL_SUCCESS;
 }
@@ -755,9 +870,8 @@ static int8_t sn_grs_core_request(struct nsdl_s *handle, sn_nsdl_addr_s *src_add
  *
 */
 
-sn_nsdl_resource_info_s *sn_grs_search_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path, uint8_t search_method)
+sn_nsdl_dynamic_resource_parameters_s *sn_grs_search_resource(struct grs_s *handle, uint16_t pathlen, uint8_t *path, uint8_t search_method)
 {
-
     /* Local variables */
     uint8_t                     *path_temp_ptr          = NULL;
     /* Check parameters */
@@ -771,11 +885,13 @@ sn_nsdl_resource_info_s *sn_grs_search_resource(struct grs_s *handle, uint16_t p
     /* Searchs exact path */
     if (search_method == SN_GRS_SEARCH_METHOD) {
         /* Scan all nodes on list */
-        ns_list_foreach(sn_nsdl_resource_info_s, resource_search_temp, &handle->resource_root_list) {
+        ns_list_foreach(sn_nsdl_dynamic_resource_parameters_s, resource_search_temp, &handle->resource_root_list) {
             /* If length equals.. */
-            if (resource_search_temp->pathlen == pathlen) {
+            if (resource_search_temp->static_resource_parameters->pathlen == pathlen) {
                 /* Compare paths, If same return node pointer*/
-                if (0 == memcmp(resource_search_temp->path, path_temp_ptr, pathlen)) {
+                if (0 == memcmp(resource_search_temp->static_resource_parameters->path,
+                                path_temp_ptr,
+                                pathlen)) {
                     return resource_search_temp;
                 }
             }
@@ -784,11 +900,13 @@ sn_nsdl_resource_info_s *sn_grs_search_resource(struct grs_s *handle, uint16_t p
     /* Search also subresources, eg. dr/x -> returns dr/x/1, dr/x/2 etc... */
     else if (search_method == SN_GRS_DELETE_METHOD) {
         /* Scan all nodes on list */
-        ns_list_foreach(sn_nsdl_resource_info_s, resource_search_temp, &handle->resource_root_list) {
-            uint8_t *temp_path = resource_search_temp->path;
-            if (resource_search_temp->pathlen > pathlen &&
+        ns_list_foreach(sn_nsdl_dynamic_resource_parameters_s, resource_search_temp, &handle->resource_root_list) {
+            uint8_t *temp_path = resource_search_temp->static_resource_parameters->path;
+            if (resource_search_temp->static_resource_parameters->pathlen > pathlen &&
                     (*(temp_path + (uint8_t)pathlen) == '/') &&
-                    0 == memcmp(resource_search_temp->path, path_temp_ptr, pathlen)) {
+                    0 == memcmp(resource_search_temp->static_resource_parameters->path,
+                                path_temp_ptr,
+                                pathlen)) {
                 return resource_search_temp;
             }
         }
@@ -797,135 +915,6 @@ sn_nsdl_resource_info_s *sn_grs_search_resource(struct grs_s *handle, uint16_t p
     /* If there was not nodes we wanted, return NULL */
     return NULL;
 }
-
-
-/**
- * \fn  static int8_t sn_grs_add_resource_to_list(sn_grs_resource_info_s *resource_ptr)
- *
- * \brief Adds given resource to resource list
- *
- *  \param  *resource_ptr           Pointer to the path string to be search
- *
- *  \return 0 = SN_NSDL_SUCCESS, -1 = SN_NSDL_FAILURE
- *
-*/
-static int8_t sn_grs_add_resource_to_list(struct grs_s *handle, sn_nsdl_resource_info_s *resource_ptr)
-{
-    /* Local variables */
-    uint8_t *path_start_ptr = NULL;
-    uint16_t path_len = 0;
-    sn_nsdl_resource_info_s *resource_copy_ptr = NULL;
-
-    /* Allocate memory for the resource info copy */
-    if (!resource_ptr->pathlen) { //Dead code
-        return SN_NSDL_FAILURE;
-    }
-    resource_copy_ptr = handle->sn_grs_alloc(sizeof(sn_nsdl_resource_info_s));
-    if (resource_copy_ptr == NULL) {
-        return SN_NSDL_FAILURE;
-    }
-
-    /* Set everything to zero  */
-    memset(resource_copy_ptr, 0, sizeof(sn_nsdl_resource_info_s));
-
-    resource_copy_ptr->mode = resource_ptr->mode;
-    resource_copy_ptr->resourcelen = resource_ptr->resourcelen;
-    resource_copy_ptr->sn_grs_dyn_res_callback = resource_ptr->sn_grs_dyn_res_callback;
-    resource_copy_ptr->access = resource_ptr->access;
-    resource_copy_ptr->publish_uri = resource_ptr->publish_uri;
-    resource_copy_ptr->external_memory_block = resource_ptr->external_memory_block;
-
-    /* Remove '/' - chars from the beginning and from the end */
-
-    path_len = resource_ptr->pathlen;
-    path_start_ptr = sn_grs_convert_uri(&path_len, resource_ptr->path);
-
-    /* Allocate memory for the path */
-    resource_copy_ptr->path = handle->sn_grs_alloc(path_len);
-    if (!resource_copy_ptr->path) {
-        sn_grs_resource_info_free(handle, resource_copy_ptr);
-        return SN_NSDL_FAILURE;
-    }
-
-    /* Update pathlen */
-    resource_copy_ptr->pathlen = path_len;
-
-    /* Copy path string to the copy */
-    memcpy(resource_copy_ptr->path, path_start_ptr, resource_copy_ptr->pathlen);
-
-    /* Allocate memory for the resource, and copy it to copy */
-    if (resource_ptr->resource) {
-        resource_copy_ptr->resource = handle->sn_grs_alloc(resource_ptr->resourcelen);
-        if (!resource_copy_ptr->resource) {
-            sn_grs_resource_info_free(handle, resource_copy_ptr);
-            return SN_NSDL_FAILURE;
-        }
-        memcpy(resource_copy_ptr->resource, resource_ptr->resource, resource_ptr->resourcelen);
-    }
-
-
-
-    /* If resource parameters exists, copy them */
-    if (resource_ptr->resource_parameters_ptr) {
-        resource_copy_ptr->resource_parameters_ptr = handle->sn_grs_alloc(sizeof(sn_nsdl_resource_parameters_s));
-        if (!resource_copy_ptr->resource_parameters_ptr) {
-            sn_grs_resource_info_free(handle, resource_copy_ptr);
-            return SN_NSDL_FAILURE;
-        }
-
-        memset(resource_copy_ptr->resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
-
-        resource_copy_ptr->resource_parameters_ptr->resource_type_len = resource_ptr->resource_parameters_ptr->resource_type_len;
-
-//        resource_copy_ptr->resource_parameters_ptr->mime_content_type = resource_ptr->resource_parameters_ptr->mime_content_type;
-
-        resource_copy_ptr->resource_parameters_ptr->observable = resource_ptr->resource_parameters_ptr->observable;
-
-        if (resource_ptr->resource_parameters_ptr->resource_type_ptr) {
-            resource_copy_ptr->resource_parameters_ptr->resource_type_ptr = handle->sn_grs_alloc(resource_ptr->resource_parameters_ptr->resource_type_len);
-            if (!resource_copy_ptr->resource_parameters_ptr->resource_type_ptr) {
-                sn_grs_resource_info_free(handle, resource_copy_ptr);
-                return SN_NSDL_FAILURE;
-            }
-            memcpy(resource_copy_ptr->resource_parameters_ptr->resource_type_ptr, resource_ptr->resource_parameters_ptr->resource_type_ptr, resource_ptr->resource_parameters_ptr->resource_type_len);
-        }
-
-        resource_copy_ptr->resource_parameters_ptr->interface_description_len = resource_ptr->resource_parameters_ptr->interface_description_len;
-
-        if (resource_ptr->resource_parameters_ptr->interface_description_ptr) {
-            resource_copy_ptr->resource_parameters_ptr->interface_description_ptr = handle->sn_grs_alloc(resource_ptr->resource_parameters_ptr->interface_description_len);
-            if (!resource_copy_ptr->resource_parameters_ptr->interface_description_ptr) {
-                sn_grs_resource_info_free(handle, resource_copy_ptr);
-                return SN_NSDL_FAILURE;
-            }
-            memcpy(resource_copy_ptr->resource_parameters_ptr->interface_description_ptr, resource_ptr->resource_parameters_ptr->interface_description_ptr, resource_ptr->resource_parameters_ptr->interface_description_len);
-        }
-
-        /* Copy auto observation parameter */
-        /* todo: aobs not supported ATM - needs fixing */
-        /*      if(resource_ptr->resource_parameters_ptr->auto_obs_ptr && resource_ptr->resource_parameters_ptr->auto_obs_len)
-                {
-                    resource_copy_ptr->resource_parameters_ptr->auto_obs_ptr = sn_grs_alloc(resource_ptr->resource_parameters_ptr->auto_obs_len);
-                    if(!resource_copy_ptr->resource_parameters_ptr->auto_obs_ptr)
-                    {
-                        sn_grs_resource_info_free(resource_copy_ptr);
-                        return SN_NSDL_FAILURE;
-                    }
-                    memcpy(resource_copy_ptr->resource_parameters_ptr->auto_obs_ptr, resource_ptr->resource_parameters_ptr->auto_obs_ptr, resource_ptr->resource_parameters_ptr->auto_obs_len);
-                    resource_copy_ptr->resource_parameters_ptr->auto_obs_len = resource_ptr->resource_parameters_ptr->auto_obs_len;
-                }
-
-                resource_copy_ptr->resource_parameters_ptr->coap_content_type = resource_ptr->resource_parameters_ptr->coap_content_type;
-                */
-    }
-
-    /* Add copied resource to the linked list */
-    ns_list_add_to_start(&handle->resource_root_list, resource_copy_ptr);
-    ++handle->resource_root_count;
-
-    return SN_NSDL_SUCCESS;
-}
-
 
 /**
  * \fn  static uint8_t *sn_grs_convert_uri(uint16_t *uri_len, uint8_t *uri_ptr)
@@ -970,48 +959,45 @@ static uint8_t *sn_grs_convert_uri(uint16_t *uri_len, uint8_t *uri_ptr)
  *  \return 0 if success, -1 if failed
  *
 */
-static int8_t sn_grs_resource_info_free(struct grs_s *handle, sn_nsdl_resource_info_s *resource_ptr)
+static int8_t sn_grs_resource_info_free(struct grs_s *handle, sn_nsdl_dynamic_resource_parameters_s *resource_ptr)
 {
     if (resource_ptr) {
-        if (resource_ptr->resource_parameters_ptr) {
-            if (!resource_ptr->is_put) {
-                if (resource_ptr->resource_parameters_ptr->interface_description_ptr) {
-                    handle->sn_grs_free(resource_ptr->resource_parameters_ptr->interface_description_ptr);
-                    resource_ptr->resource_parameters_ptr->interface_description_ptr = 0;
-                }
-
-                if (resource_ptr->resource_parameters_ptr->resource_type_ptr) {
-                    handle->sn_grs_free(resource_ptr->resource_parameters_ptr->resource_type_ptr);
-                    resource_ptr->resource_parameters_ptr->resource_type_ptr = 0;
-                }
-            }
-
-            /* Todo: aobs not supported ATM - needs fixing */
-            /*
-            if(resource_ptr->resource_parameters_ptr->auto_obs_ptr)
-            {
-                sn_grs_free(resource_ptr->resource_parameters_ptr->auto_obs_ptr);
-                resource_ptr->resource_parameters_ptr->auto_obs_ptr = 0;
-            }
-            */
-
-            handle->sn_grs_free(resource_ptr->resource_parameters_ptr);
-            resource_ptr->resource_parameters_ptr = 0;
+#ifdef MEMORY_OPTIMIZED_API
+        if (resource_ptr->free_on_delete) {
+            handle->sn_grs_free(resource_ptr);
         }
+        return SN_NSDL_FAILURE;
+#else
+        if (resource_ptr->static_resource_parameters &&
+                resource_ptr->static_resource_parameters->free_on_delete) {
+            if (resource_ptr->static_resource_parameters->interface_description_ptr) {
+                handle->sn_grs_free(resource_ptr->static_resource_parameters->interface_description_ptr);
+                resource_ptr->static_resource_parameters->interface_description_ptr = 0;
+            }
 
-        if (!resource_ptr->is_put) {
-            if (resource_ptr->path) {
-                handle->sn_grs_free(resource_ptr->path);
-                resource_ptr->path = 0;
+            if (resource_ptr->static_resource_parameters->resource_type_ptr) {
+                handle->sn_grs_free(resource_ptr->static_resource_parameters->resource_type_ptr);
+                resource_ptr->static_resource_parameters->resource_type_ptr = 0;
             }
-            if (resource_ptr->resource) {
-                handle->sn_grs_free(resource_ptr->resource);
-                resource_ptr->resource = 0;
+
+            if (resource_ptr->static_resource_parameters->path) {
+                handle->sn_grs_free(resource_ptr->static_resource_parameters->path);
+                resource_ptr->static_resource_parameters->path = 0;
             }
+
+            if (resource_ptr->static_resource_parameters->resource) {
+                handle->sn_grs_free(resource_ptr->static_resource_parameters->resource);
+                resource_ptr->static_resource_parameters->resource = 0;
+            }
+
+            handle->sn_grs_free(resource_ptr->static_resource_parameters);
+            resource_ptr->static_resource_parameters = 0;
         }
-        handle->sn_grs_free(resource_ptr);
-
+        if (resource_ptr->free_on_delete) {
+            handle->sn_grs_free(resource_ptr);
+        }
         return SN_NSDL_SUCCESS;
+#endif
     }
     return SN_NSDL_FAILURE; //Dead code?
 }
@@ -1022,15 +1008,13 @@ void sn_grs_mark_resources_as_registered(struct nsdl_s *handle)
         return;
     }
 
-    const sn_nsdl_resource_info_s *temp_resource;
+    sn_nsdl_dynamic_resource_parameters_s *temp_resource;
 
     temp_resource = sn_grs_get_first_resource(handle->grs);
 
     while (temp_resource) {
-        if (temp_resource->resource_parameters_ptr) {
-            if (temp_resource->resource_parameters_ptr->registered == SN_NDSL_RESOURCE_REGISTERING) {
-                temp_resource->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_REGISTERED;
-            }
+        if (temp_resource->registered == SN_NDSL_RESOURCE_REGISTERING) {
+            temp_resource->registered = SN_NDSL_RESOURCE_REGISTERED;
         }
         temp_resource = sn_grs_get_next_resource(handle->grs, temp_resource);
     }

--- a/source/libNsdl/src/sn_grs2.c
+++ b/source/libNsdl/src/sn_grs2.c
@@ -21,6 +21,7 @@
  * \brief General resource server.
  *
  */
+#ifdef MBED_CLIENT_C_NEW_API
 #include <string.h>
 #include <stdlib.h>
 #include "ns_list.h"
@@ -1019,3 +1020,4 @@ void sn_grs_mark_resources_as_registered(struct nsdl_s *handle)
         temp_resource = sn_grs_get_next_resource(handle->grs, temp_resource);
     }
 }
+#endif

--- a/source/libNsdl/src/sn_nsdl.c
+++ b/source/libNsdl/src/sn_nsdl.c
@@ -20,6 +20,8 @@
  *
  */
 
+#ifndef MBED_CLIENT_C_NEW_API
+
 #include <string.h>
 
 #include "ns_types.h"
@@ -2604,3 +2606,6 @@ extern void *sn_nsdl_get_context(const struct nsdl_s * const handle)
     }
     return handle->context;
 }
+
+#endif
+

--- a/source/libNsdl/src/sn_nsdl2.c
+++ b/source/libNsdl/src/sn_nsdl2.c
@@ -1,0 +1,2606 @@
+/*
+ * Copyright (c) 2011-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * \file sn_nsdl.c
+ *
+ * \brief Nano service device library
+ *
+ */
+
+#include <string.h>
+
+#include "ns_types.h"
+#include "sn_nsdl.h"
+#include "sn_coap_header.h"
+#include "sn_coap_protocol.h"
+#include "sn_coap_protocol_internal.h"
+#include "sn_nsdl_lib.h"
+#include "sn_grs.h"
+#include "sn_config.h"
+#include "mbed-trace/mbed_trace.h"
+
+#define TRACE_GROUP "coap"
+/* Defines */
+#define TRACE_GROUP "coap"
+#define RESOURCE_DIR_LEN                2
+#define EP_NAME_PARAMETERS_LEN          3
+#define ET_PARAMETER_LEN                3
+#define LT_PARAMETER_LEN                3
+#define DOMAIN_PARAMETER_LEN            2
+#define RT_PARAMETER_LEN                3
+#define IF_PARAMETER_LEN                3
+#define OBS_PARAMETER_LEN               3
+#define AOBS_PARAMETER_LEN              8
+#define COAP_CON_PARAMETER_LEN          3
+#define BS_EP_PARAMETER_LEN             3
+#define BS_QUEUE_MODE_PARAMATER_LEN     2
+
+#define SN_NSDL_EP_REGISTER_MESSAGE     1
+#define SN_NSDL_EP_UPDATE_MESSAGE       2
+
+#define SN_NSDL_MSG_UNDEFINED           0
+#define SN_NSDL_MSG_REGISTER            1
+#define SN_NSDL_MSG_UNREGISTER          2
+#define SN_NSDL_MSG_UPDATE              3
+#define SN_NSDL_MSG_BOOTSTRAP           4
+
+#ifdef YOTTA_CFG_DISABLE_OBS_FEATURE
+#define COAP_DISABLE_OBS_FEATURE YOTTA_CFG_DISABLE_OBS_FEATURE
+#elif defined MBED_CONF_MBED_CLIENT_COAP_DISABLE_OBS_FEATURE
+#define COAP_DISABLE_OBS_FEATURE MBED_CONF_MBED_CLIENT_COAP_DISABLE_OBS_FEATURE
+#endif
+
+#ifdef YOTTA_CFG_DISABLE_BOOTSTRAP_FEATURE
+#define MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE YOTTA_CFG_DISABLE_BOOTSTRAP_FEATURE
+#elif defined MBED_CONF_MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+#define MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE MBED_CONF_MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+#endif
+
+
+/* Constants */
+static uint8_t      ep_name_parameter_string[]  = {'e', 'p', '='};      /* Endpoint name. A unique name for the registering node in a domain.  */
+static uint8_t      resource_path_ptr[]         = {'r', 'd'};           /* For resource directory */
+static uint8_t      resource_type_parameter[]   = {'r', 't', '='};      /* Resource type. Only once for registration */
+#ifndef COAP_DISABLE_OBS_FEATURE
+static uint8_t      obs_parameter[]             = {'o', 'b', 's'};      /* Observable */
+#endif
+//static uint8_t    aobs_parameter[]            = {'a','o','b','s',';','i','d','='};    /* Auto-observable - TBD */
+static uint8_t      if_description_parameter[]  = {'i', 'f', '='};      /* Interface description. Only once */
+static uint8_t      ep_lifetime_parameter[]     = {'l', 't', '='};      /* Lifetime. Number of seconds that this registration will be valid for. Must be updated within this time, or will be removed. */
+static uint8_t      ep_domain_parameter[]       = {'d', '='};           /* Domain name. If this parameter is missing, a default domain is assumed. */
+static uint8_t      coap_con_type_parameter[]   = {'c', 't', '='};      /* CoAP content type */
+/* * OMA BS parameters * */
+static uint8_t bs_uri[]                         = {'b', 's'};
+static uint8_t bs_ep_name[]                     = {'e', 'p', '='};
+static uint8_t et_parameter[]                   = {'e', 't', '='};      /* Endpoint type */
+static uint8_t bs_queue_mode[]                  = {'b', '='};
+
+/* Function prototypes */
+static uint16_t         sn_nsdl_internal_coap_send(struct nsdl_s *handle, sn_coap_hdr_s *coap_header_ptr, sn_nsdl_addr_s *dst_addr_ptr, uint8_t message_description);
+static void             sn_nsdl_resolve_nsp_address(struct nsdl_s *handle);
+int8_t                  sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *message_ptr, uint8_t updating_registeration);
+static uint16_t         sn_nsdl_calculate_registration_body_size(struct nsdl_s *handle, uint8_t updating_registeration, int8_t *error);
+static uint8_t          sn_nsdl_calculate_uri_query_option_len(sn_nsdl_ep_parameters_s *endpoint_info_ptr, uint8_t msg_type);
+static int8_t           sn_nsdl_fill_uri_query_options(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *parameter_ptr, sn_coap_hdr_s *source_msg_ptr, uint8_t msg_type);
+static int8_t           sn_nsdl_local_rx_function(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, sn_nsdl_addr_s *address_ptr);
+static int8_t           sn_nsdl_resolve_ep_information(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr);
+static uint8_t          sn_nsdl_itoa_len(uint8_t value);
+static uint8_t          *sn_nsdl_itoa(uint8_t *ptr, uint8_t value);
+static int32_t          sn_nsdl_atoi(uint8_t *ptr, uint8_t len);
+static uint32_t         sn_nsdl_ahextoi(uint8_t *ptr, uint8_t len);
+static int8_t           sn_nsdl_resolve_lwm2m_address(struct nsdl_s *handle, uint8_t *uri, uint16_t uri_len);
+static int8_t           sn_nsdl_process_oma_tlv(struct nsdl_s *handle, uint8_t *data_ptr, uint16_t data_len);
+static void             sn_nsdl_check_oma_bs_status(struct nsdl_s *handle);
+static int8_t           sn_nsdl_create_oma_device_object_base(struct nsdl_s *handle, sn_nsdl_oma_device_t *oma_device_setup_ptr, sn_nsdl_oma_binding_and_mode_t binding_and_mode);
+static int8_t           set_endpoint_info(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *endpoint_info_ptr);
+static bool             validateParameters(sn_nsdl_ep_parameters_s *parameter_ptr);
+static bool             validate(uint8_t* ptr, uint32_t len, char illegalChar);
+static bool             sn_nsdl_check_uint_overflow(uint16_t resource_size, uint16_t param_a, uint16_t param_b);
+
+int8_t sn_nsdl_destroy(struct nsdl_s *handle)
+{
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    if (handle->ep_information_ptr) {
+        if (handle->ep_information_ptr->endpoint_name_ptr) {
+            handle->sn_nsdl_free(handle->ep_information_ptr->endpoint_name_ptr);
+            handle->ep_information_ptr->endpoint_name_ptr = 0;
+        }
+        if (handle->ep_information_ptr->domain_name_ptr) {
+            handle->sn_nsdl_free(handle->ep_information_ptr->domain_name_ptr);
+            handle->ep_information_ptr->domain_name_ptr = 0;
+            handle->ep_information_ptr->domain_name_len = 0;
+        }
+        if (handle->ep_information_ptr->location_ptr) {
+            handle->sn_nsdl_free(handle->ep_information_ptr->location_ptr);
+            handle->ep_information_ptr->location_ptr = 0;
+            handle->ep_information_ptr->location_len = 0;
+        }
+        if (handle->ep_information_ptr->type_ptr) {
+            handle->sn_nsdl_free(handle->ep_information_ptr->type_ptr);
+            handle->ep_information_ptr->type_ptr = 0;
+        }
+
+        if (handle->ep_information_ptr->lifetime_ptr)
+
+        {
+            handle->sn_nsdl_free(handle->ep_information_ptr->lifetime_ptr);
+            handle->ep_information_ptr->lifetime_ptr = 0;
+        }
+
+        handle->sn_nsdl_free(handle->ep_information_ptr);
+        handle->ep_information_ptr = 0;
+    }
+
+    if (handle->nsp_address_ptr) {
+        if (handle->nsp_address_ptr->omalw_address_ptr) {
+            if (handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+                handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
+                handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = 0;
+            }
+            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr);
+        }
+
+        handle->sn_nsdl_free(handle->nsp_address_ptr);
+        handle->nsp_address_ptr = 0;
+    }
+
+    if (handle->oma_bs_address_ptr) {
+        handle->sn_nsdl_free(handle->oma_bs_address_ptr);
+    }
+
+    /* Destroy also libCoap and grs part of libNsdl */
+    sn_coap_protocol_destroy(handle->grs->coap);
+    sn_grs_destroy(handle->grs);
+    handle->sn_nsdl_free(handle);
+
+    return SN_NSDL_SUCCESS;
+}
+
+struct nsdl_s *sn_nsdl_init(uint8_t (*sn_nsdl_tx_cb)(struct nsdl_s *, sn_nsdl_capab_e , uint8_t *, uint16_t, sn_nsdl_addr_s *),
+                            uint8_t (*sn_nsdl_rx_cb)(struct nsdl_s *, sn_coap_hdr_s *, sn_nsdl_addr_s *),
+                            void *(*sn_nsdl_alloc)(uint16_t), void (*sn_nsdl_free)(void *))
+{
+    /* Check pointers and define function pointers */
+    if (!sn_nsdl_alloc || !sn_nsdl_free || !sn_nsdl_tx_cb || !sn_nsdl_rx_cb) {
+        return NULL;
+    }
+
+    struct nsdl_s *handle = NULL;
+
+    handle = sn_nsdl_alloc(sizeof(struct nsdl_s));
+
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    memset(handle, 0, sizeof(struct nsdl_s));
+
+    /* Define function pointers */
+    handle->sn_nsdl_alloc = sn_nsdl_alloc;
+    handle->sn_nsdl_free = sn_nsdl_free;
+
+    handle->sn_nsdl_tx_callback = sn_nsdl_tx_cb;
+    handle->sn_nsdl_rx_callback = sn_nsdl_rx_cb;
+
+    /* Initialize ep parameters struct */
+    if (!handle->ep_information_ptr) {
+        handle->ep_information_ptr = handle->sn_nsdl_alloc(sizeof(sn_nsdl_ep_parameters_s));
+        if (!handle->ep_information_ptr) {
+            sn_nsdl_free(handle);
+            return NULL;
+        }
+        memset(handle->ep_information_ptr, 0, sizeof(sn_nsdl_ep_parameters_s));
+    }
+
+    handle->grs = sn_grs_init(sn_nsdl_tx_cb, &sn_nsdl_local_rx_function, sn_nsdl_alloc, sn_nsdl_free);
+
+    /* Initialize GRS */
+    if (handle->grs == NULL) {
+        handle->sn_nsdl_free(handle->ep_information_ptr);
+        handle->ep_information_ptr = 0;
+        sn_nsdl_free(handle);
+        return NULL;
+    }
+
+    sn_nsdl_resolve_nsp_address(handle);
+
+    handle->sn_nsdl_endpoint_registered = SN_NSDL_ENDPOINT_NOT_REGISTERED;
+    // By default bootstrap msgs are handled in nsdl
+    handle->handle_bootstrap_msg = true;
+    handle->context = NULL;
+
+    return handle;
+}
+
+uint16_t sn_nsdl_register_endpoint(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *endpoint_info_ptr)
+{
+    /* Local variables */
+    sn_coap_hdr_s   *register_message_ptr;
+    uint16_t        message_id  = 0;
+
+    if (endpoint_info_ptr == NULL || handle == NULL) {
+        return 0;
+    }
+
+    /*** Build endpoint register message ***/
+
+    /* Allocate memory for header struct */
+    register_message_ptr = sn_coap_parser_alloc_message(handle->grs->coap);
+    if (register_message_ptr == NULL) {
+        return 0;
+    }
+
+    /* Fill message fields -> confirmable post to specified NSP path */
+    register_message_ptr->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+    register_message_ptr->msg_code = COAP_MSG_CODE_REQUEST_POST;
+
+    /* Allocate memory for the extended options list */
+    if (sn_coap_parser_alloc_options(handle->grs->coap, register_message_ptr) == NULL) {
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+        register_message_ptr = 0;
+        return 0;
+    }
+
+    register_message_ptr->uri_path_len = sizeof(resource_path_ptr);
+    register_message_ptr->uri_path_ptr = resource_path_ptr;
+
+    /* Fill Uri-query options */
+    if( SN_NSDL_FAILURE == sn_nsdl_fill_uri_query_options(handle, endpoint_info_ptr,
+                                                          register_message_ptr, SN_NSDL_EP_REGISTER_MESSAGE) ){
+        register_message_ptr->uri_path_ptr = NULL;
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+        return 0;
+    }
+
+    if (endpoint_info_ptr->ds_register_mode == REGISTER_WITH_RESOURCES) {
+        /* Built body for message */
+        if (sn_nsdl_build_registration_body(handle, register_message_ptr, 0) == SN_NSDL_FAILURE) {
+            register_message_ptr->uri_path_ptr = NULL;
+            register_message_ptr->options_list_ptr->uri_host_ptr = NULL;
+            sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+            return 0;
+        }
+    }
+
+    /* Clean (possible) existing and save new endpoint info to handle */
+    if (set_endpoint_info(handle, endpoint_info_ptr) == -1) {
+        if (register_message_ptr->payload_ptr) {
+            handle->sn_nsdl_free(register_message_ptr->payload_ptr);
+            register_message_ptr->payload_ptr = NULL;
+        }
+
+        register_message_ptr->uri_path_ptr = NULL;
+        register_message_ptr->options_list_ptr->uri_host_ptr = NULL;
+
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+
+        return 0;
+    }
+
+    /* Build and send coap message to NSP */
+    message_id = sn_nsdl_internal_coap_send(handle, register_message_ptr, handle->nsp_address_ptr->omalw_address_ptr, SN_NSDL_MSG_REGISTER);
+
+    if (register_message_ptr->payload_ptr) {
+        handle->sn_nsdl_free(register_message_ptr->payload_ptr);
+        register_message_ptr->payload_ptr = NULL;
+    }
+
+    register_message_ptr->uri_path_ptr = NULL;
+    register_message_ptr->options_list_ptr->uri_host_ptr = NULL;
+
+    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+
+    return message_id;
+}
+
+uint16_t sn_nsdl_unregister_endpoint(struct nsdl_s *handle)
+{
+    /* Local variables */
+    sn_coap_hdr_s   *unregister_message_ptr;
+    uint8_t         *temp_ptr = 0;
+    uint16_t        message_id = 0;
+
+    /* Check parameters */
+    if (handle == NULL) {
+        return 0;
+    }
+
+    /* Check that EP have been registered */
+    if (sn_nsdl_is_ep_registered(handle)) {
+
+        /* Memory allocation for unregister message */
+        unregister_message_ptr = sn_coap_parser_alloc_message(handle->grs->coap);
+        if (!unregister_message_ptr) {
+            return 0;
+        }
+
+        /* Fill unregister message */
+        unregister_message_ptr->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+        unregister_message_ptr->msg_code = COAP_MSG_CODE_REQUEST_DELETE;
+
+        if(handle->ep_information_ptr->location_ptr) {
+            unregister_message_ptr->uri_path_len = handle->ep_information_ptr->location_len;
+            unregister_message_ptr->uri_path_ptr = handle->sn_nsdl_alloc(unregister_message_ptr->uri_path_len);
+            if (!unregister_message_ptr->uri_path_ptr) {
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, unregister_message_ptr);
+                return 0;
+            }
+
+            temp_ptr = unregister_message_ptr->uri_path_ptr;
+
+            memcpy(temp_ptr , handle->ep_information_ptr->location_ptr, handle->ep_information_ptr->location_len);
+        } else {
+            unregister_message_ptr->uri_path_len = (RESOURCE_DIR_LEN + 1 + handle->ep_information_ptr->domain_name_len + 1 + handle->ep_information_ptr->endpoint_name_len);
+            unregister_message_ptr->uri_path_ptr = handle->sn_nsdl_alloc(unregister_message_ptr->uri_path_len);
+            if (!unregister_message_ptr->uri_path_ptr) {
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, unregister_message_ptr);
+                return 0;
+            }
+
+            temp_ptr = unregister_message_ptr->uri_path_ptr;
+
+            memcpy(temp_ptr, resource_path_ptr, RESOURCE_DIR_LEN);
+            temp_ptr += RESOURCE_DIR_LEN;
+
+            *temp_ptr++ = '/';
+
+            memcpy(temp_ptr , handle->ep_information_ptr->domain_name_ptr, handle->ep_information_ptr->domain_name_len);
+            temp_ptr += handle->ep_information_ptr->domain_name_len;
+
+            *temp_ptr++ = '/';
+
+            memcpy(temp_ptr , handle->ep_information_ptr->endpoint_name_ptr, handle->ep_information_ptr->endpoint_name_len);
+        }
+
+        /* Send message */
+        message_id = sn_nsdl_internal_coap_send(handle, unregister_message_ptr, handle->nsp_address_ptr->omalw_address_ptr, SN_NSDL_MSG_UNREGISTER);
+
+        /* Free memory */
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, unregister_message_ptr);
+
+    }
+
+    return message_id;
+}
+
+uint16_t sn_nsdl_update_registration(struct nsdl_s *handle, uint8_t *lt_ptr, uint8_t lt_len)
+{
+    /* Local variables */
+    sn_coap_hdr_s   *register_message_ptr;
+    uint8_t         *temp_ptr;
+    sn_nsdl_ep_parameters_s temp_parameters;
+    uint16_t        message_id = 0;
+
+    /* Check parameters */
+    if (handle == NULL) {
+        return 0;
+    }
+
+    if (!sn_nsdl_is_ep_registered(handle)){
+        return 0;
+    }
+
+    memset(&temp_parameters, 0, sizeof(sn_nsdl_ep_parameters_s));
+
+    temp_parameters.lifetime_len = lt_len;
+    temp_parameters.lifetime_ptr = lt_ptr;
+
+    /*** Build endpoint register update message ***/
+
+    /* Allocate memory for header struct */
+    register_message_ptr = sn_coap_parser_alloc_message(handle->grs->coap);
+    if (register_message_ptr == NULL) {
+        return 0;
+    }
+
+    /* Fill message fields -> confirmable post to specified NSP path */
+    register_message_ptr->msg_type  =   COAP_MSG_TYPE_CONFIRMABLE;
+    register_message_ptr->msg_code  =   COAP_MSG_CODE_REQUEST_POST;
+
+    if(handle->ep_information_ptr->location_ptr) {
+        register_message_ptr->uri_path_len  =   handle->ep_information_ptr->location_len;    /* = Only location set by Device Server*/
+
+        register_message_ptr->uri_path_ptr  =   handle->sn_nsdl_alloc(register_message_ptr->uri_path_len);
+        if (!register_message_ptr->uri_path_ptr) {
+            sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+            return 0;
+        }
+
+        temp_ptr = register_message_ptr->uri_path_ptr;
+
+        /* location */
+        memcpy(temp_ptr, handle->ep_information_ptr->location_ptr, handle->ep_information_ptr->location_len);
+    } else {
+        register_message_ptr->uri_path_len  =   sizeof(resource_path_ptr) + handle->ep_information_ptr->domain_name_len + handle->ep_information_ptr->endpoint_name_len + 2;    /* = rd/domain/endpoint */
+
+        register_message_ptr->uri_path_ptr  =   handle->sn_nsdl_alloc(register_message_ptr->uri_path_len);
+        if (!register_message_ptr->uri_path_ptr) {
+            sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+            return 0;
+        }
+
+        temp_ptr = register_message_ptr->uri_path_ptr;
+
+        /* rd/ */
+        memcpy(temp_ptr, resource_path_ptr, sizeof(resource_path_ptr));
+        temp_ptr += sizeof(resource_path_ptr);
+        *temp_ptr++ = '/';
+
+        /* rd/DOMAIN/ */
+        memcpy(temp_ptr, handle->ep_information_ptr->domain_name_ptr, handle->ep_information_ptr->domain_name_len);
+        temp_ptr += handle->ep_information_ptr->domain_name_len;
+        *temp_ptr++ = '/';
+
+        /* rd/domain/ENDPOINT */
+        memcpy(temp_ptr, handle->ep_information_ptr->endpoint_name_ptr, handle->ep_information_ptr->endpoint_name_len);
+    }
+
+    /* Allocate memory for the extended options list */
+    if (sn_coap_parser_alloc_options(handle->grs->coap, register_message_ptr) == NULL) {
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+        return 0;
+    }
+
+    /* Fill Uri-query options */
+    sn_nsdl_fill_uri_query_options(handle, &temp_parameters, register_message_ptr, SN_NSDL_EP_UPDATE_MESSAGE);
+
+    /* Build payload */
+    if (handle->ep_information_ptr->ds_register_mode == REGISTER_WITH_RESOURCES) {
+
+        if (sn_nsdl_build_registration_body(handle, register_message_ptr, 1) == SN_NSDL_FAILURE) {
+            sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+            return 0;
+        }
+    }
+
+    /* Build and send coap message to NSP */
+    message_id = sn_nsdl_internal_coap_send(handle, register_message_ptr, handle->nsp_address_ptr->omalw_address_ptr, SN_NSDL_MSG_UPDATE);
+
+    if (register_message_ptr->payload_ptr) {
+        handle->sn_nsdl_free(register_message_ptr->payload_ptr);
+    }
+    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, register_message_ptr);
+
+    return message_id;
+}
+
+int8_t sn_nsdl_set_endpoint_location(struct nsdl_s *handle, uint8_t *location_ptr, uint8_t location_len)
+{
+    if(!handle || !location_ptr || (location_len == 0)) {
+        return -1;
+    }
+
+    handle->sn_nsdl_free(handle->ep_information_ptr->location_ptr);
+    handle->ep_information_ptr->location_ptr = handle->sn_nsdl_alloc(location_len);
+    memcpy(handle->ep_information_ptr->location_ptr, location_ptr, location_len);
+    handle->ep_information_ptr->location_len = location_len;
+
+    return 0;
+}
+
+void sn_nsdl_nsp_lost(struct nsdl_s *handle)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return;
+    }
+
+    handle->sn_nsdl_endpoint_registered = SN_NSDL_ENDPOINT_NOT_REGISTERED;
+}
+
+int8_t sn_nsdl_is_ep_registered(struct nsdl_s *handle)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return handle->sn_nsdl_endpoint_registered;
+}
+
+uint16_t sn_nsdl_send_observation_notification(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
+        uint8_t *payload_ptr, uint16_t payload_len,
+        sn_coap_observe_e observe,
+        sn_coap_msg_type_e message_type, sn_coap_content_format_e content_format)
+{
+    return sn_nsdl_send_observation_notification_with_uri_path(handle,
+                                                               token_ptr,
+                                                               token_len,
+                                                               payload_ptr,
+                                                               payload_len,
+                                                               observe,
+                                                               message_type,
+                                                               content_format,
+                                                               NULL,
+                                                               0);
+}
+
+uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
+        uint8_t *payload_ptr, uint16_t payload_len,
+        sn_coap_observe_e observe,
+        sn_coap_msg_type_e message_type, uint8_t content_format,
+        uint8_t *uri_path_ptr, uint16_t uri_path_len)
+{
+    sn_coap_hdr_s   *notification_message_ptr;
+    uint16_t        return_msg_id = 0;
+
+    /* Check parameters */
+    if (handle == NULL || handle->grs == NULL) {
+        return 0;
+    }
+
+    /* Allocate and initialize memory for header struct */
+    notification_message_ptr = sn_coap_parser_alloc_message(handle->grs->coap);
+    if (notification_message_ptr == NULL) {
+        return 0;
+    }
+
+    if (sn_coap_parser_alloc_options(handle->grs->coap, notification_message_ptr) == NULL) {
+        handle->sn_nsdl_free(notification_message_ptr);
+        return 0;
+    }
+
+    /* Fill header */
+    notification_message_ptr->msg_type = message_type;
+    notification_message_ptr->msg_code = COAP_MSG_CODE_RESPONSE_CONTENT;
+
+    /* Fill token */
+    notification_message_ptr->token_len = token_len;
+    notification_message_ptr->token_ptr = token_ptr;
+
+    /* Fill payload */
+    notification_message_ptr->payload_len = payload_len;
+    notification_message_ptr->payload_ptr = payload_ptr;
+
+    /* Fill uri path */
+    notification_message_ptr->uri_path_len = uri_path_len;
+    notification_message_ptr->uri_path_ptr = uri_path_ptr;
+
+    /* Fill observe */
+    notification_message_ptr->options_list_ptr->observe = observe;
+
+    /* Fill content format */
+    notification_message_ptr->content_format = content_format;
+
+    /* Send message */
+    if (sn_nsdl_send_coap_message(handle, handle->nsp_address_ptr->omalw_address_ptr, notification_message_ptr) == SN_NSDL_FAILURE) {
+        return_msg_id = 0;
+    } else {
+        return_msg_id = notification_message_ptr->msg_id;
+    }
+
+    /* Free memory */
+    notification_message_ptr->uri_path_ptr = NULL;
+    notification_message_ptr->payload_ptr = NULL;
+    notification_message_ptr->token_ptr = NULL;
+
+    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, notification_message_ptr);
+
+    return return_msg_id;
+}
+
+
+/* * * * * * * * * * */
+/* ~ OMA functions ~ */
+/* * * * * * * * * * */
+
+uint16_t sn_nsdl_oma_bootstrap(struct nsdl_s *handle, sn_nsdl_addr_s *bootstrap_address_ptr,
+                               sn_nsdl_ep_parameters_s *endpoint_info_ptr,
+                               sn_nsdl_bs_ep_info_t *bootstrap_endpoint_info_ptr)
+{
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    /* Local variables */
+    sn_coap_hdr_s bootstrap_coap_header;
+    uint8_t *uri_query_tmp_ptr;
+    uint16_t message_id = 0;
+
+    /* Check parameters */
+    if (!bootstrap_address_ptr || !bootstrap_endpoint_info_ptr || !endpoint_info_ptr || !handle) {
+        return 0;
+    }
+    /* Create device object */
+    if (handle->handle_bootstrap_msg) {
+        if (sn_nsdl_create_oma_device_object_base(handle, bootstrap_endpoint_info_ptr->device_object, endpoint_info_ptr->binding_and_mode) < 0) {
+            return 0;
+        }
+
+        handle->sn_nsdl_oma_bs_done_cb = bootstrap_endpoint_info_ptr->oma_bs_status_cb;
+        handle->sn_nsdl_oma_bs_done_cb_handle = bootstrap_endpoint_info_ptr->oma_bs_status_cb_handle;
+    }
+
+
+    /* XXX FIX -- Init CoAP header struct */
+    sn_coap_parser_init_message(&bootstrap_coap_header);
+
+    if (!sn_coap_parser_alloc_options(handle->grs->coap, &bootstrap_coap_header)) {
+        return 0;
+    }
+
+    /* Build bootstrap start message */
+    bootstrap_coap_header.msg_code = COAP_MSG_CODE_REQUEST_POST;
+    bootstrap_coap_header.msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+
+    bootstrap_coap_header.uri_path_ptr = bs_uri;
+    bootstrap_coap_header.uri_path_len = sizeof(bs_uri);
+
+    uri_query_tmp_ptr = handle->sn_nsdl_alloc(endpoint_info_ptr->endpoint_name_len + BS_EP_PARAMETER_LEN);
+    if (!uri_query_tmp_ptr) {
+        handle->sn_nsdl_free(bootstrap_coap_header.options_list_ptr);
+        return 0;
+    }
+
+    memcpy(uri_query_tmp_ptr, bs_ep_name, BS_EP_PARAMETER_LEN);
+    memcpy((uri_query_tmp_ptr + BS_EP_PARAMETER_LEN), endpoint_info_ptr->endpoint_name_ptr, endpoint_info_ptr->endpoint_name_len);
+
+    bootstrap_coap_header.options_list_ptr->uri_query_len = endpoint_info_ptr->endpoint_name_len + BS_EP_PARAMETER_LEN;
+    bootstrap_coap_header.options_list_ptr->uri_query_ptr = uri_query_tmp_ptr;
+
+    /* Save bootstrap server address */
+    handle->oma_bs_address_len = bootstrap_address_ptr->addr_len;       /* Length.. */
+    handle->oma_bs_address_ptr = handle->sn_nsdl_alloc(handle->oma_bs_address_len);     /* Address.. */
+    if (!handle->oma_bs_address_ptr) {
+        handle->sn_nsdl_free(bootstrap_coap_header.options_list_ptr);
+        handle->sn_nsdl_free(uri_query_tmp_ptr);
+        return 0;
+    }
+    memcpy(handle->oma_bs_address_ptr, bootstrap_address_ptr->addr_ptr, handle->oma_bs_address_len);
+    handle->oma_bs_port = bootstrap_address_ptr->port;                  /* And port */
+
+    /* Send message */
+    message_id = sn_nsdl_internal_coap_send(handle, &bootstrap_coap_header, bootstrap_address_ptr, SN_NSDL_MSG_BOOTSTRAP);
+
+    /* Free allocated memory */
+    handle->sn_nsdl_free(uri_query_tmp_ptr);
+    handle->sn_nsdl_free(bootstrap_coap_header.options_list_ptr);
+
+    return message_id;
+#else
+    return 0;
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+
+}
+
+omalw_certificate_list_t *sn_nsdl_get_certificates(struct nsdl_s *handle)
+{
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    sn_nsdl_resource_info_s *resource_ptr = 0;;
+    omalw_certificate_list_t *certi_list_ptr = 0;
+
+    /* Check parameters */
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    certi_list_ptr = handle->sn_nsdl_alloc(sizeof(omalw_certificate_list_t));
+
+    if (!certi_list_ptr) {
+        return NULL;
+    }
+
+    /* Get private key resource */
+    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/5");
+    if (!resource_ptr) {
+        handle->sn_nsdl_free(certi_list_ptr);
+        return NULL;
+    }
+    certi_list_ptr->own_private_key_ptr = resource_ptr->resource;
+    certi_list_ptr->own_private_key_len = resource_ptr->resourcelen;
+
+    /* Get client certificate resource */
+    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/4");
+    if (!resource_ptr) {
+        handle->sn_nsdl_free(certi_list_ptr);
+        return NULL;
+    }
+    certi_list_ptr->certificate_ptr[0] = resource_ptr->resource;
+    certi_list_ptr->certificate_len[0] = resource_ptr->resourcelen;
+
+    /* Get root certificate resource */
+    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/3");
+    if (!resource_ptr) {
+        handle->sn_nsdl_free(certi_list_ptr);
+        return NULL;
+    }
+    certi_list_ptr->certificate_ptr[1] = resource_ptr->resource;
+    certi_list_ptr->certificate_len[1] = resource_ptr->resourcelen;
+
+    /* return filled list */
+    return certi_list_ptr;
+#else
+    return NULL;
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+}
+
+int8_t sn_nsdl_update_certificates(struct nsdl_s *handle, omalw_certificate_list_t *certificate_ptr, uint8_t certificate_chain)
+{
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    (void)certificate_chain;
+
+    /* Check pointers */
+    if (!certificate_ptr || !handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    sn_nsdl_resource_info_s *resource_ptr = 0;;
+
+    /* Get private key resource */
+    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/5");
+    if (!resource_ptr) {
+        return SN_NSDL_FAILURE;
+    }
+    handle->sn_nsdl_free(resource_ptr->resource);
+    resource_ptr->resource = certificate_ptr->own_private_key_ptr;
+    resource_ptr->resourcelen = certificate_ptr->own_private_key_len;
+
+    /* Get client certificate resource */
+    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/4");
+    if (!resource_ptr) {
+        return SN_NSDL_FAILURE;
+    }
+    handle->sn_nsdl_free(resource_ptr->resource);
+    resource_ptr->resource = certificate_ptr->certificate_ptr[0];
+    resource_ptr->resourcelen = certificate_ptr->certificate_len[0];
+
+    /* Get root certificate resource */
+    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/3");
+    if (!resource_ptr) {
+        return SN_NSDL_FAILURE;
+    }
+    handle->sn_nsdl_free(resource_ptr->resource);
+    resource_ptr->resource = certificate_ptr->certificate_ptr[1];
+    resource_ptr->resourcelen = certificate_ptr->certificate_len[1];
+
+    return SN_NSDL_SUCCESS;
+#else
+    return SN_NSDL_FAILURE;
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+}
+
+int8_t sn_nsdl_create_oma_device_object(struct nsdl_s *handle, sn_nsdl_oma_device_t *device_object_ptr)
+{
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    sn_nsdl_resource_info_s *resource_temp = 0;
+    uint8_t path[8] = "3/0/11/0";
+
+    if (!device_object_ptr || !handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* * Error code * */
+
+    /* Get first error message */
+    resource_temp = sn_grs_search_resource(handle->grs, 8, path, SN_GRS_SEARCH_METHOD);
+
+    while (resource_temp) {
+        if (resource_temp->resource) {
+            /* If no error code set */
+            if (*resource_temp->resource == 0) {
+                /* Set error code */
+                *resource_temp->resource = (uint8_t)device_object_ptr->error_code;
+                resource_temp->resourcelen = 1;
+
+                sn_nsdl_update_resource(handle, resource_temp);
+                return SN_NSDL_SUCCESS;
+            }
+            break;
+        }
+
+        if (path[7] == '9') {
+            return SN_NSDL_FAILURE;
+        }
+
+        path[7]++;
+        resource_temp = sn_grs_search_resource(handle->grs, 8, path, SN_GRS_SEARCH_METHOD);
+    }
+
+    /* Create new resource for this error */
+    resource_temp = handle->sn_nsdl_alloc(sizeof(sn_nsdl_resource_info_s));
+    if (!resource_temp) {
+        return SN_NSDL_FAILURE;
+    }
+
+    memset(resource_temp, 0, sizeof(sn_nsdl_resource_info_s));
+
+    resource_temp->access = SN_GRS_GET_ALLOWED;
+    resource_temp->mode = SN_GRS_DYNAMIC;
+
+    resource_temp->path = path;
+    resource_temp->pathlen = 8;
+
+    resource_temp->resource = handle->sn_nsdl_alloc(1);
+    if (!resource_temp->resource) {
+        handle->sn_nsdl_free(resource_temp);
+        return SN_NSDL_FAILURE;
+    }
+
+    *resource_temp->resource = (uint8_t)device_object_ptr->error_code;
+    resource_temp->resourcelen = 1;
+
+    resource_temp->resource_parameters_ptr = handle->sn_nsdl_alloc(sizeof(sn_nsdl_resource_parameters_s));
+
+    if (!resource_temp->resource_parameters_ptr) {
+        handle->sn_nsdl_free(resource_temp->resource);
+        handle->sn_nsdl_free(resource_temp);
+
+        return SN_NSDL_FAILURE;
+    }
+
+    memset(resource_temp->resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
+
+    sn_nsdl_create_resource(handle, resource_temp);
+
+    handle->sn_nsdl_free(resource_temp->resource);
+    handle->sn_nsdl_free(resource_temp->resource_parameters_ptr);
+    handle->sn_nsdl_free(resource_temp);
+
+    return SN_NSDL_SUCCESS;
+#else
+    return SN_NSDL_FAILURE;
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+}
+
+char *sn_nsdl_get_version(void)
+{
+#if defined(YOTTA_MBED_CLIENT_C_VERSION_STRING)
+    return YOTTA_MBED_CLIENT_C_VERSION_STRING;
+#elif defined(VERSION)
+    return VERSION;
+#else
+    return "0.0.0";
+#endif
+}
+
+
+int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet_ptr, uint16_t packet_len, sn_nsdl_addr_s *src_ptr)
+{
+    sn_coap_hdr_s           *coap_packet_ptr    = NULL;
+    sn_coap_hdr_s           *coap_response_ptr  = NULL;
+    sn_nsdl_resource_info_s *resource = NULL;
+    /* Check parameters */
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Parse CoAP packet */
+    coap_packet_ptr = sn_coap_protocol_parse(handle->grs->coap, src_ptr, packet_len, packet_ptr, (void *)handle);
+
+    /* Check if parsing was successfull */
+    if (coap_packet_ptr == (sn_coap_hdr_s *)NULL) {
+        return SN_NSDL_FAILURE;
+    }
+#if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+    // Pass block to application if external_memory_block is set
+    if(coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVING) {
+        resource = sn_nsdl_get_resource(handle, coap_packet_ptr->uri_path_len, coap_packet_ptr->uri_path_ptr);
+        if(resource && resource->external_memory_block) {
+            sn_coap_protocol_block_remove(handle->grs->coap,
+                                          src_ptr,
+                                          coap_packet_ptr->payload_len,
+                                          coap_packet_ptr->payload_ptr);
+        } else {
+            resource = NULL;
+        }
+    }
+#endif
+    /* Check, if coap itself sends response, or block receiving is ongoing... */
+    if (coap_packet_ptr->coap_status != COAP_STATUS_OK &&
+            coap_packet_ptr->coap_status != COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED &&coap_packet_ptr &&
+            !resource) {
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+        return SN_NSDL_SUCCESS;
+    }
+
+    /* If proxy options added, return not supported */
+    if (coap_packet_ptr->options_list_ptr) {
+        if (coap_packet_ptr->options_list_ptr->proxy_uri_len) {
+            coap_response_ptr = sn_coap_build_response(handle->grs->coap, coap_packet_ptr, COAP_MSG_CODE_RESPONSE_PROXYING_NOT_SUPPORTED);
+            if (coap_response_ptr) {
+                sn_nsdl_send_coap_message(handle, src_ptr, coap_response_ptr);
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_response_ptr);
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+                return SN_NSDL_SUCCESS;
+            } else {
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+                return SN_NSDL_FAILURE;
+            }
+        }
+    }
+
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * */
+    /* If message is response message, call RX callback  */
+    /* * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+    if ((coap_packet_ptr->msg_code > COAP_MSG_CODE_REQUEST_DELETE) || (coap_packet_ptr->msg_type == COAP_MSG_TYPE_ACKNOWLEDGEMENT)) {
+        int8_t retval = sn_nsdl_local_rx_function(handle, coap_packet_ptr, src_ptr);
+        if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+            handle->sn_nsdl_free(coap_packet_ptr->payload_ptr);
+            coap_packet_ptr->payload_ptr = 0;
+        }
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+        return retval;
+    }
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    /* * If OMA bootstrap message... * */
+    bool bootstrap_msg = src_ptr && (handle->oma_bs_address_len == src_ptr->addr_len) &&
+            (handle->oma_bs_port == src_ptr->port) &&
+            !memcmp(handle->oma_bs_address_ptr, src_ptr->addr_ptr, handle->oma_bs_address_len);
+    // Pass bootstrap data to application
+    if (bootstrap_msg && !handle->handle_bootstrap_msg) {
+        handle->sn_nsdl_rx_callback(handle, coap_packet_ptr,src_ptr);
+        sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+        return SN_NSDL_SUCCESS;
+    }
+    // Internal handling
+    else if (bootstrap_msg) {
+        /* TLV message. Parse message and check status of the OMA bootstrap  */
+        /* process. If ok, call cb function and return. Otherwise send error */
+        /* and return failure.                                               */
+
+        if (coap_packet_ptr->content_format == 99) { //todo check message type
+            /* TLV parsing failed. Send response to get non-tlv messages */
+            if (sn_nsdl_process_oma_tlv(handle, coap_packet_ptr->payload_ptr, coap_packet_ptr->payload_len) == SN_NSDL_FAILURE) {
+                coap_response_ptr = sn_coap_build_response(handle->grs->coap, coap_packet_ptr, COAP_MSG_CODE_RESPONSE_NOT_ACCEPTABLE);
+                if (coap_response_ptr) {
+                    sn_nsdl_send_coap_message(handle, src_ptr, coap_response_ptr);
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_response_ptr);
+                } else {
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+                    return SN_NSDL_FAILURE;
+                }
+            }
+            /* Success TLV parsing */
+            else {
+                coap_response_ptr = sn_coap_build_response(handle->grs->coap, coap_packet_ptr, COAP_MSG_CODE_RESPONSE_CREATED);
+                if (coap_response_ptr) {
+                    sn_nsdl_send_coap_message(handle, src_ptr, coap_response_ptr);
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_response_ptr);
+
+                } else {
+                    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+                    return SN_NSDL_FAILURE;
+                }
+                sn_nsdl_check_oma_bs_status(handle);
+            }
+
+            sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+            return SN_NSDL_SUCCESS;
+        }
+
+        /* Non - TLV message */
+        else if (coap_packet_ptr->content_format == 97) {
+            sn_grs_process_coap(handle, coap_packet_ptr, src_ptr);
+
+            /* Todo: move this copying to sn_nsdl_check_oma_bs_status(), also from TLV parser */
+            /* Security mode */
+            if (*(coap_packet_ptr->uri_path_ptr + (coap_packet_ptr->uri_path_len - 1)) == '2') {
+                handle->nsp_address_ptr->omalw_server_security = (omalw_server_security_t)sn_nsdl_atoi(coap_packet_ptr->payload_ptr, coap_packet_ptr->payload_len);
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+            }
+
+            /* NSP address */
+            else if (*(coap_packet_ptr->uri_path_ptr + (coap_packet_ptr->uri_path_len - 1)) == '0') {
+                sn_nsdl_resolve_lwm2m_address(handle, coap_packet_ptr->payload_ptr, coap_packet_ptr->payload_len);
+                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+            }
+
+            sn_nsdl_check_oma_bs_status(handle);
+        } else {
+            sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
+            return SN_NSDL_FAILURE;
+        }
+
+
+        return SN_NSDL_SUCCESS;
+    }
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+
+    /* * * * * * * * * * * * * * * */
+    /* Other messages are for GRS  */
+    /* * * * * * * * * * * * * * * */
+
+    return sn_grs_process_coap(handle, coap_packet_ptr, src_ptr);
+}
+
+int8_t sn_nsdl_exec(struct nsdl_s *handle, uint32_t time)
+{
+    if(!handle || !handle->grs){
+        return SN_NSDL_FAILURE;
+    }
+    /* Call CoAP execution function */
+    return sn_coap_protocol_exec(handle->grs->coap, time);
+}
+
+sn_nsdl_resource_info_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path_ptr)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    return sn_grs_search_resource(handle->grs, pathlen, path_ptr, SN_GRS_SEARCH_METHOD);
+}
+
+
+/**
+ * \fn static uint16_t sn_nsdl_internal_coap_send(struct nsdl_s *handle, sn_coap_hdr_s *coap_header_ptr, sn_nsdl_addr_s *dst_addr_ptr, uint8_t message_description)
+ *
+ *
+ * \brief To send NSDL messages. Stores message id?s and message description to catch response from NSP server
+ * \param   *handle             Pointer to nsdl-library handle
+ * \param   *coap_header_ptr    Pointer to the CoAP message header to be sent
+ * \param   *dst_addr_ptr       Pointer to the address structure that contains destination address information
+ * \param   message_description Message description to be stored to list for waiting response
+ *
+ * \return  message id, 0 if failed
+ */
+static uint16_t sn_nsdl_internal_coap_send(struct nsdl_s *handle, sn_coap_hdr_s *coap_header_ptr, sn_nsdl_addr_s *dst_addr_ptr, uint8_t message_description)
+{
+
+    tr_debug("sn_nsdl_internal_coap_send");
+    uint8_t     *coap_message_ptr   = NULL;
+    int32_t     coap_message_len    = 0;
+    uint16_t    coap_header_len     = 0;
+
+#if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not used at all, this part of code will not be compiled */
+    int8_t ret_val = prepare_blockwise_message(handle->grs->coap, coap_header_ptr);
+    if( 0 != ret_val ) {
+        return 0;
+    }
+#endif
+
+    coap_message_len = sn_coap_builder_calc_needed_packet_data_size_2(coap_header_ptr, handle->grs->coap->sn_coap_block_data_size);
+    tr_debug("sn_nsdl_internal_coap_send - msg len after calc: [%d]", coap_message_len);
+    if (coap_message_len == 0) {
+        return 0;
+    }
+
+    coap_message_ptr = handle->sn_nsdl_alloc(coap_message_len);
+    if (!coap_message_ptr) {
+        return 0;
+    }
+
+    coap_header_len = coap_header_ptr->payload_len;
+    /* Build message */
+    if (sn_coap_protocol_build(handle->grs->coap, dst_addr_ptr, coap_message_ptr, coap_header_ptr, (void *)handle) < 0) {
+        handle->sn_nsdl_free(coap_message_ptr);
+        return 0;
+    }
+
+    /* If mesage type is confirmable, save it to list to wait for reply */
+    if (coap_header_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE) {
+        if (message_description == SN_NSDL_MSG_REGISTER) {
+            handle->register_msg_id = coap_header_ptr->msg_id;
+            handle->register_msg_len = coap_header_len;
+        }
+        else if (message_description == SN_NSDL_MSG_UNREGISTER) {
+            handle->unregister_msg_id = coap_header_ptr->msg_id;
+        }
+        else if (message_description == SN_NSDL_MSG_UPDATE) {
+            handle->update_register_msg_id = coap_header_ptr->msg_id;
+            handle->update_register_msg_len = coap_header_len;
+        }
+        else if (message_description == SN_NSDL_MSG_BOOTSTRAP) {
+            handle->bootstrap_msg_id = coap_header_ptr->msg_id;
+        }
+    }
+
+    handle->sn_nsdl_tx_callback(handle, SN_NSDL_PROTOCOL_COAP, coap_message_ptr, coap_message_len, dst_addr_ptr);
+    handle->sn_nsdl_free(coap_message_ptr);
+
+    return coap_header_ptr->msg_id;
+}
+
+/**
+ * \fn static void sn_nsdl_resolve_nsp_address(struct nsdl_s *handle)
+ *
+ * \brief Resolves NSP server address.
+ *
+ * \param *handle Pointer to nsdl-library handle
+ * \note Application must set NSP address with set_nsp_address
+ */
+static void sn_nsdl_resolve_nsp_address(struct nsdl_s *handle)
+{
+    /* Local variables */
+    if (!handle->nsp_address_ptr) {
+        //allocate only if previously not allocated
+        handle->nsp_address_ptr = handle->sn_nsdl_alloc(sizeof(sn_nsdl_oma_server_info_t));
+    }
+
+    if (handle->nsp_address_ptr) {
+        handle->nsp_address_ptr->omalw_server_security = SEC_NOT_SET;
+        handle->nsp_address_ptr->omalw_address_ptr = handle->sn_nsdl_alloc(sizeof(sn_nsdl_addr_s));
+        if (handle->nsp_address_ptr->omalw_address_ptr) {
+            memset(handle->nsp_address_ptr->omalw_address_ptr, 0, sizeof(sn_nsdl_addr_s));
+            handle->nsp_address_ptr->omalw_address_ptr->type = SN_NSDL_ADDRESS_TYPE_NONE;
+        }
+    }
+}
+
+static int8_t sn_nsdl_create_oma_device_object_base(struct nsdl_s *handle, sn_nsdl_oma_device_t *oma_device_setup_ptr, sn_nsdl_oma_binding_and_mode_t binding_and_mode)
+{
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    sn_nsdl_resource_info_s new_resource;
+    uint8_t object_path[8] = "3/0/11/0";
+    uint8_t resource_temp[3];
+    uint8_t x = 0;
+
+    if (!oma_device_setup_ptr) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* * Create resources. * */
+
+    /* These resources can be created multiple times. */
+    memset(&new_resource, 0, sizeof(sn_nsdl_resource_info_s));
+    new_resource.resource_parameters_ptr = handle->sn_nsdl_alloc(sizeof(sn_nsdl_resource_parameters_s));
+    if (!new_resource.resource_parameters_ptr) {
+        return SN_NSDL_FAILURE;
+    }
+
+    memset(new_resource.resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
+
+    /* Create error - resource */
+    new_resource.mode = SN_GRS_STATIC;
+    new_resource.access = SN_GRS_GET_ALLOWED;
+
+    new_resource.path = object_path;
+    new_resource.pathlen = 8;
+
+    sn_nsdl_itoa(resource_temp, (uint8_t)oma_device_setup_ptr->error_code);
+
+    new_resource.resource = resource_temp;
+    new_resource.resourcelen = 1;
+
+    if (sn_nsdl_create_resource(handle, &new_resource) != SN_NSDL_SUCCESS) {
+        handle->sn_nsdl_free(new_resource.resource_parameters_ptr);
+        return SN_NSDL_FAILURE;
+    }
+
+    /* These resources can be only once, during OMA bootstrap.. */
+    /* Create supported binding and modes */
+    object_path[5] = '6';
+    new_resource.path = object_path;
+    new_resource.pathlen = 6;
+
+    if (binding_and_mode & 0x01) {
+        resource_temp[x] = 'U';
+        x++;
+        if (binding_and_mode & 0x02) {
+            resource_temp[x] = 'Q';
+            x++;
+        }
+    }
+    if (binding_and_mode & 0x04) {
+        resource_temp[x] = 'S';
+        x++;
+        if ((binding_and_mode & 0x02) && !(binding_and_mode & 0x01)) {
+            resource_temp[x] = 'Q';
+            x++;
+        }
+    }
+
+    new_resource.resourcelen = x;
+
+    if (new_resource.resourcelen) {
+        new_resource.resource = resource_temp;
+    } else {
+        new_resource.resource = 0;
+    }
+
+
+    if (sn_nsdl_create_resource(handle, &new_resource) != SN_NSDL_SUCCESS) {
+        handle->sn_nsdl_free(new_resource.resource_parameters_ptr);
+        return SN_NSDL_FAILURE;
+    }
+
+
+    /* Create dynamic reboot object */
+    new_resource.mode = SN_GRS_DYNAMIC;
+
+    new_resource.access = SN_GRS_POST_ALLOWED;
+
+    object_path[4] = '4';
+
+    new_resource.path = object_path;
+    new_resource.pathlen = 5;
+
+    new_resource.resourcelen = 0;
+    new_resource.resource = 0;
+
+    new_resource.sn_grs_dyn_res_callback = oma_device_setup_ptr->sn_oma_device_boot_callback;
+
+    if (sn_nsdl_create_resource(handle, &new_resource) != SN_NSDL_SUCCESS) {
+        handle->sn_nsdl_free(new_resource.resource_parameters_ptr);
+        return SN_NSDL_FAILURE;
+    }
+
+    handle->sn_nsdl_free(new_resource.resource_parameters_ptr);
+    return SN_NSDL_SUCCESS;
+#else
+    return SN_NSDL_FAILURE;
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+}
+
+/**
+ * \fn int8_t sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *message_ptr, uint8_t updating_registeration)
+ *
+ * \brief   To build GRS resources to registration message payload
+ * \param *handle Pointer to nsdl-library handle
+ * \param   *message_ptr Pointer to CoAP message header
+ *
+ * \return  SN_NSDL_SUCCESS = 0, Failed = -1
+ */
+int8_t sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *message_ptr, uint8_t updating_registeration)
+{
+    tr_debug("sn_nsdl_build_registration_body");
+    /* Local variables */
+    uint8_t                 *temp_ptr;
+    const sn_nsdl_resource_info_s   *resource_temp_ptr;
+
+    /* Calculate needed memory and allocate */
+    int8_t error = 0;
+    uint16_t msg_len = sn_nsdl_calculate_registration_body_size(handle, updating_registeration, &error);
+    if (SN_NSDL_FAILURE == error) {
+        return error;
+    }
+
+    if (!msg_len) {
+        return SN_NSDL_SUCCESS;
+    } else {
+        message_ptr->payload_len = msg_len;
+    }
+    tr_debug("sn_nsdl_build_registration_body - body size: [%d]", message_ptr->payload_len);
+    message_ptr->payload_ptr = handle->sn_nsdl_alloc(message_ptr->payload_len);
+    if (!message_ptr->payload_ptr) {
+        return SN_NSDL_FAILURE;
+    }
+
+    /* Build message */
+    temp_ptr = message_ptr->payload_ptr;
+
+    resource_temp_ptr = sn_grs_get_first_resource(handle->grs);
+
+    /* Loop trough all resources */
+    while (resource_temp_ptr) {
+        /* if resource needs to be registered */
+        if (resource_temp_ptr->resource_parameters_ptr && resource_temp_ptr->publish_uri) {
+            if (updating_registeration && resource_temp_ptr->resource_parameters_ptr->registered == SN_NDSL_RESOURCE_REGISTERED) {
+                resource_temp_ptr = sn_grs_get_next_resource(handle->grs, resource_temp_ptr);
+                continue;
+            } else {
+                resource_temp_ptr->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_REGISTERED;
+            }
+
+            /* If not first resource, add '.' to separator */
+            if (temp_ptr != message_ptr->payload_ptr) {
+                *temp_ptr++ = ',';
+            }
+
+            *temp_ptr++ = '<';
+            *temp_ptr++ = '/';
+            memcpy(temp_ptr, resource_temp_ptr->path, resource_temp_ptr->pathlen);
+            temp_ptr += resource_temp_ptr->pathlen;
+            *temp_ptr++ = '>';
+
+            /* Resource attributes */
+            if (resource_temp_ptr->resource_parameters_ptr->resource_type_len) {
+                *temp_ptr++ = ';';
+                memcpy(temp_ptr, resource_type_parameter, RT_PARAMETER_LEN);
+                temp_ptr += RT_PARAMETER_LEN;
+                *temp_ptr++ = '"';
+                memcpy(temp_ptr, resource_temp_ptr->resource_parameters_ptr->resource_type_ptr, resource_temp_ptr->resource_parameters_ptr->resource_type_len);
+                temp_ptr += resource_temp_ptr->resource_parameters_ptr->resource_type_len;
+                *temp_ptr++ = '"';
+            }
+
+            if (resource_temp_ptr->resource_parameters_ptr->interface_description_len) {
+                *temp_ptr++ = ';';
+                memcpy(temp_ptr, if_description_parameter, IF_PARAMETER_LEN);
+                temp_ptr += IF_PARAMETER_LEN;
+                *temp_ptr++ = '"';
+                memcpy(temp_ptr, resource_temp_ptr->resource_parameters_ptr->interface_description_ptr, resource_temp_ptr->resource_parameters_ptr->interface_description_len);
+                temp_ptr += resource_temp_ptr->resource_parameters_ptr->interface_description_len;
+                *temp_ptr++ = '"';
+            }
+
+            if (resource_temp_ptr->resource_parameters_ptr->coap_content_type != 0) {
+                *temp_ptr++ = ';';
+                memcpy(temp_ptr, coap_con_type_parameter, COAP_CON_PARAMETER_LEN);
+                temp_ptr += COAP_CON_PARAMETER_LEN;
+                *temp_ptr++ = '"';
+                temp_ptr = sn_nsdl_itoa(temp_ptr, resource_temp_ptr->resource_parameters_ptr->coap_content_type);
+                *temp_ptr++ = '"';
+            }
+
+            /* ;obs */
+             // This needs to be re-visited and may be need an API for maganging obs value for different server implementation
+#ifndef COAP_DISABLE_OBS_FEATURE
+            if (resource_temp_ptr->resource_parameters_ptr->observable) {
+                *temp_ptr++ = ';';
+                memcpy(temp_ptr, obs_parameter, OBS_PARAMETER_LEN);
+                temp_ptr += OBS_PARAMETER_LEN;
+            }
+#endif
+            /* ;aobs;id= */
+            /* todo: aosb not supported ATM */
+            /*
+            if((resource_temp_ptr->resource_parameters_ptr->auto_obs_len > 0 && resource_temp_ptr->resource_parameters_ptr->auto_obs_len <= 8) &&
+                    resource_temp_ptr->resource_parameters_ptr->auto_obs_ptr)
+            {
+                uint8_t i = 0;
+
+                *temp_ptr++ = ';';
+                memcpy(temp_ptr, aobs_parameter, AOBS_PARAMETER_LEN);
+                temp_ptr += AOBS_PARAMETER_LEN;
+
+                while(i < resource_temp_ptr->resource_parameters_ptr->auto_obs_len)
+                {
+                    temp_ptr = sn_nsdl_itoa(temp_ptr, *(resource_temp_ptr->resource_parameters_ptr->auto_obs_ptr + i));
+                    i++;
+                }
+            }
+            */
+
+        }
+
+        resource_temp_ptr = sn_grs_get_next_resource(handle->grs, resource_temp_ptr);
+    }
+
+    return SN_NSDL_SUCCESS;
+}
+
+/**
+ * \fn static uint16_t sn_nsdl_calculate_registration_body_size(struct nsdl_s *handle, uint8_t updating_registeration, int8_t *error)
+ *
+ *
+ * \brief   Calculates registration message payload size
+ * \param   *handle                 Pointer to nsdl-library handle
+ * \param   *updating_registeration Pointer to list of GRS resources
+ * \param   *error                  Error code, SN_NSDL_SUCCESS or SN_NSDL_FAILURE
+ *
+ * \return  Needed payload size
+ */
+static uint16_t sn_nsdl_calculate_registration_body_size(struct nsdl_s *handle, uint8_t updating_registeration, int8_t *error)
+{
+    tr_debug("sn_nsdl_calculate_registration_body_size");
+    /* Local variables */
+    uint16_t return_value = 0;
+    *error = SN_NSDL_SUCCESS;
+    const sn_nsdl_resource_info_s *resource_temp_ptr;
+
+    /* check pointer */
+    resource_temp_ptr = sn_grs_get_first_resource(handle->grs);
+
+    while (resource_temp_ptr) {
+        if (resource_temp_ptr->resource_parameters_ptr && resource_temp_ptr->publish_uri) {
+            if (updating_registeration && resource_temp_ptr->resource_parameters_ptr->registered == SN_NDSL_RESOURCE_REGISTERED) {
+                resource_temp_ptr = sn_grs_get_next_resource(handle->grs, resource_temp_ptr);
+                continue;
+            }
+
+            /* If not first resource, then '.' will be added */
+            if (return_value) {
+                if (sn_nsdl_check_uint_overflow(return_value, 1, 0)) {
+                    return_value++;
+                } else {
+                    *error = SN_NSDL_FAILURE;
+                    break;
+                }
+            }
+
+            /* Count length for the resource path </path> */
+            if (sn_nsdl_check_uint_overflow(return_value, 3,resource_temp_ptr->pathlen)) {
+                return_value += (3 + resource_temp_ptr->pathlen);
+            } else {
+                *error = SN_NSDL_FAILURE;
+                break;
+            }
+
+            /* Count lengths of the attributes */
+
+            /* Resource type parameter */
+            if (resource_temp_ptr->resource_parameters_ptr->resource_type_len) {
+                /* ;rt="restype" */
+                if (sn_nsdl_check_uint_overflow(return_value, 6, resource_temp_ptr->resource_parameters_ptr->resource_type_len)) {
+                    return_value += (6 + resource_temp_ptr->resource_parameters_ptr->resource_type_len);
+                } else {
+                    *error = SN_NSDL_FAILURE;
+                    break;
+                }
+            }
+
+            /* Interface description parameter */
+            if (resource_temp_ptr->resource_parameters_ptr->interface_description_len) {
+                /* ;if="iftype" */
+                if (sn_nsdl_check_uint_overflow(return_value, 6, resource_temp_ptr->resource_parameters_ptr->interface_description_len)) {
+                    return_value += (6 + resource_temp_ptr->resource_parameters_ptr->interface_description_len);
+                } else {
+                    *error = SN_NSDL_FAILURE;
+                    break;
+                }
+            }
+
+            if (resource_temp_ptr->resource_parameters_ptr->coap_content_type != 0) {
+                /* ;if="content" */
+                uint8_t len = sn_nsdl_itoa_len(resource_temp_ptr->resource_parameters_ptr->coap_content_type);
+                if (sn_nsdl_check_uint_overflow(return_value, 6, len)) {
+                    return_value += (6 + len);
+                } else {
+                    *error = SN_NSDL_FAILURE;
+                    break;
+                }
+            }
+#ifndef COAP_DISABLE_OBS_FEATURE
+            // This needs to be re-visited and may be need an API for maganging obs value for different server implementation
+            if (resource_temp_ptr->resource_parameters_ptr->observable) {
+                if (sn_nsdl_check_uint_overflow(return_value, 4, 0)) {
+                    return_value += 4;
+                } else {
+                    *error = SN_NSDL_FAILURE;
+                    break;
+                }
+            }
+#endif
+        }
+        resource_temp_ptr = sn_grs_get_next_resource(handle->grs, resource_temp_ptr);
+    }
+    return return_value;
+}
+
+/**
+ * \fn static uint8_t sn_nsdl_calculate_uri_query_option_len(sn_nsdl_ep_parameters_s *endpoint_info_ptr, uint8_t msg_type)
+ *
+ *
+ * \brief Calculates needed uri query option length
+ *
+ * \param *endpoint_info_ptr    Pointer to endpoint info structure
+ * \param msg_type              Message type
+ *
+ * \return  number of parameters in uri query
+ */
+static uint8_t sn_nsdl_calculate_uri_query_option_len(sn_nsdl_ep_parameters_s *endpoint_info_ptr, uint8_t msg_type)
+{
+    uint8_t return_value = 0;
+    uint8_t number_of_parameters = 0;
+
+
+    if ((endpoint_info_ptr->endpoint_name_len != 0) && (msg_type == SN_NSDL_EP_REGISTER_MESSAGE) && endpoint_info_ptr->endpoint_name_ptr != 0) {
+        return_value += endpoint_info_ptr->endpoint_name_len;
+        return_value += EP_NAME_PARAMETERS_LEN; //ep=
+        number_of_parameters++;
+    }
+
+    if ((endpoint_info_ptr->type_len != 0) && (msg_type == SN_NSDL_EP_REGISTER_MESSAGE) && (endpoint_info_ptr->type_ptr != 0)) {
+        return_value += endpoint_info_ptr->type_len;
+        return_value += ET_PARAMETER_LEN;       //et=
+        number_of_parameters++;
+    }
+
+    if ((endpoint_info_ptr->lifetime_len != 0) && (endpoint_info_ptr->lifetime_ptr != 0)) {
+        return_value += endpoint_info_ptr->lifetime_len;
+        return_value += LT_PARAMETER_LEN;       //lt=
+        number_of_parameters++;
+    }
+
+    if ((endpoint_info_ptr->domain_name_len != 0) && (msg_type == SN_NSDL_EP_REGISTER_MESSAGE) && (endpoint_info_ptr->domain_name_ptr != 0)) {
+        return_value += endpoint_info_ptr->domain_name_len;
+        return_value += DOMAIN_PARAMETER_LEN;       //d=
+        number_of_parameters++;
+    }
+
+    if (((endpoint_info_ptr->binding_and_mode & 0x04) || (endpoint_info_ptr->binding_and_mode & 0x01)) && (msg_type == SN_NSDL_EP_REGISTER_MESSAGE)) {
+        return_value += BS_QUEUE_MODE_PARAMATER_LEN;
+
+        if (endpoint_info_ptr->binding_and_mode & 0x01) {
+            return_value++;
+        }
+        if (endpoint_info_ptr->binding_and_mode & 0x04) {
+            return_value++;
+        }
+        if ((endpoint_info_ptr->binding_and_mode & 0x02) && ((endpoint_info_ptr->binding_and_mode & 0x04) || (endpoint_info_ptr->binding_and_mode & 0x01))) {
+            return_value++;
+        }
+
+        number_of_parameters++;
+    }
+
+    if (number_of_parameters != 0) {
+        return_value += (number_of_parameters - 1);
+    }
+
+    return return_value;
+}
+
+/**
+ * \fn static int8_t sn_nsdl_fill_uri_query_options(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *parameter_ptr, sn_coap_hdr_s *source_msg_ptr, uint8_t msg_type)
+ *
+ *
+ * \brief Fills uri-query options to message header struct
+ * \param *handle           Pointer to nsdl-library handle
+ * \param *parameter_ptr    Pointer to endpoint parameters struct
+ * \param *source_msg_ptr   Pointer to CoAP header struct
+ * \param msg_type          Message type
+ *
+ * \return  SN_NSDL_SUCCESS = 0, Failed = -1
+ */
+static int8_t sn_nsdl_fill_uri_query_options(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *parameter_ptr, sn_coap_hdr_s *source_msg_ptr, uint8_t msg_type)
+{
+    uint8_t *temp_ptr = NULL;
+    if( !validateParameters(parameter_ptr) ){
+        return SN_NSDL_FAILURE;
+    }
+    source_msg_ptr->options_list_ptr->uri_query_len  = sn_nsdl_calculate_uri_query_option_len(parameter_ptr, msg_type);
+    if (source_msg_ptr->options_list_ptr->uri_query_len == 0) {
+        return 0;
+    }
+
+    source_msg_ptr->options_list_ptr->uri_query_ptr     =   handle->sn_nsdl_alloc(source_msg_ptr->options_list_ptr->uri_query_len);
+
+    if (source_msg_ptr->options_list_ptr->uri_query_ptr == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+    memset(source_msg_ptr->options_list_ptr->uri_query_ptr,0,source_msg_ptr->options_list_ptr->uri_query_len);
+
+    temp_ptr = source_msg_ptr->options_list_ptr->uri_query_ptr;
+
+    /******************************************************/
+    /* If endpoint name is configured, fill needed fields */
+    /******************************************************/
+
+    if ((parameter_ptr->endpoint_name_len != 0) && (parameter_ptr->endpoint_name_ptr != 0) && (msg_type == SN_NSDL_EP_REGISTER_MESSAGE)) {
+        /* fill endpoint name, first ?ep=, then endpoint name */
+        memcpy(temp_ptr, ep_name_parameter_string, sizeof(ep_name_parameter_string));
+        temp_ptr += EP_NAME_PARAMETERS_LEN;
+        memcpy(temp_ptr, parameter_ptr->endpoint_name_ptr, parameter_ptr->endpoint_name_len);
+        temp_ptr += parameter_ptr->endpoint_name_len;
+    }
+
+    /******************************************************/
+    /* If endpoint type is configured, fill needed fields */
+    /******************************************************/
+
+    if ((parameter_ptr->type_len != 0) && (parameter_ptr->type_ptr != 0) && (msg_type == SN_NSDL_EP_REGISTER_MESSAGE)) {
+        if (temp_ptr != source_msg_ptr->options_list_ptr->uri_query_ptr) {
+            *temp_ptr++ = '&';
+        }
+
+        memcpy(temp_ptr, et_parameter, sizeof(et_parameter));
+        temp_ptr += ET_PARAMETER_LEN;
+        memcpy(temp_ptr, parameter_ptr->type_ptr, parameter_ptr->type_len);
+        temp_ptr += parameter_ptr->type_len;
+    }
+
+
+    /******************************************************/
+    /* If lifetime is configured, fill needed fields */
+    /******************************************************/
+
+    if ((parameter_ptr->lifetime_len != 0) && (parameter_ptr->lifetime_ptr != 0)) {
+        if (temp_ptr != source_msg_ptr->options_list_ptr->uri_query_ptr) {
+            *temp_ptr++ = '&';
+        }
+
+        memcpy(temp_ptr, ep_lifetime_parameter, sizeof(ep_lifetime_parameter));
+        temp_ptr += LT_PARAMETER_LEN;
+        memcpy(temp_ptr, parameter_ptr->lifetime_ptr, parameter_ptr->lifetime_len);
+        temp_ptr += parameter_ptr->lifetime_len;
+    }
+
+    /******************************************************/
+    /* If domain is configured, fill needed fields */
+    /******************************************************/
+
+    if ((parameter_ptr->domain_name_len != 0) && (parameter_ptr->domain_name_ptr != 0) && (msg_type == SN_NSDL_EP_REGISTER_MESSAGE)) {
+        if (temp_ptr != source_msg_ptr->options_list_ptr->uri_query_ptr) {
+            *temp_ptr++ = '&';
+        }
+
+        memcpy(temp_ptr, ep_domain_parameter, sizeof(ep_domain_parameter));
+        temp_ptr += DOMAIN_PARAMETER_LEN;
+        memcpy(temp_ptr, parameter_ptr->domain_name_ptr, parameter_ptr->domain_name_len);
+        temp_ptr += parameter_ptr->domain_name_len;
+    }
+
+    /******************************************************/
+    /* If queue-mode is configured, fill needed fields    */
+    /******************************************************/
+
+    if (((parameter_ptr->binding_and_mode & 0x01) || (parameter_ptr->binding_and_mode & 0x04)) && (msg_type == SN_NSDL_EP_REGISTER_MESSAGE)) {
+        if (temp_ptr != source_msg_ptr->options_list_ptr->uri_query_ptr) {
+            *temp_ptr++ = '&';
+        }
+
+        memcpy(temp_ptr, bs_queue_mode, sizeof(bs_queue_mode));
+        temp_ptr += BS_QUEUE_MODE_PARAMATER_LEN;
+
+        if (parameter_ptr->binding_and_mode & 0x01) {
+            *temp_ptr++ = 'U';
+            if (parameter_ptr->binding_and_mode & 0x02) {
+                *temp_ptr++ = 'Q';
+            }
+        }
+
+        if (parameter_ptr->binding_and_mode & 0x04) {
+            *temp_ptr++ = 'S';
+            if ((parameter_ptr->binding_and_mode & 0x02) && !(parameter_ptr->binding_and_mode & 0x01)) {
+                *temp_ptr++ = 'Q';
+            }
+        }
+    }
+
+    return SN_NSDL_SUCCESS;
+}
+
+static bool validateParameters(sn_nsdl_ep_parameters_s *parameter_ptr)
+{
+    if( !validate( parameter_ptr->domain_name_ptr, parameter_ptr->domain_name_len, '&' ) ){
+        return false;
+    }
+
+    if( !validate( parameter_ptr->endpoint_name_ptr, parameter_ptr->endpoint_name_len, '&' ) ){
+        return false;
+    }
+
+    if( !validate( parameter_ptr->lifetime_ptr, parameter_ptr->lifetime_len, '&' ) ){
+        return false;
+    }
+
+    if( !validate( parameter_ptr->type_ptr, parameter_ptr->type_len, '&' ) ){
+        return false;
+    }
+    return true;
+}
+
+static bool validate(uint8_t* ptr, uint32_t len, char illegalChar)
+{
+    if( ptr ){
+        for( uint32_t i=0; i < len; i++ ){
+            if( ptr[i] == illegalChar ){
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * \fn static int8_t sn_nsdl_local_rx_function(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, sn_nsdl_addr_s *address_ptr)
+ *
+ * \brief If received message is reply for the message that NSDL has been sent, it is processed here. Else, packet will be sent to application.
+ * \param *handle           Pointer to nsdl-library handle
+ * \param *coap_packet_ptr  Pointer to received CoAP packet
+ * \param *address_ptr      Pointer to source address struct
+ *
+ * \return      SN_NSDL_SUCCESS = 0, Failed = -1
+ */
+static int8_t sn_nsdl_local_rx_function(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, sn_nsdl_addr_s *address_ptr)
+{
+    if ((coap_packet_ptr == 0) || (address_ptr == 0)) {
+        return -1;
+    }
+
+    bool is_reg_msg = false;
+    bool is_update_reg_msg = false;
+    bool is_unreg_msg = false;
+    if (coap_packet_ptr->msg_code == COAP_MSG_CODE_RESPONSE_CREATED) {
+        if (handle->grs->coap->sn_coap_block_data_size > 0) {
+            handle->register_msg_id += handle->register_msg_len / handle->grs->coap->sn_coap_block_data_size;
+        }
+        if (coap_packet_ptr->msg_id == handle->register_msg_id) {
+            handle->sn_nsdl_endpoint_registered = SN_NSDL_ENDPOINT_IS_REGISTERED;
+            is_reg_msg = true;
+            sn_grs_mark_resources_as_registered(handle);
+            if (sn_nsdl_resolve_ep_information(handle, coap_packet_ptr) != SN_NSDL_SUCCESS) {
+                return SN_NSDL_FAILURE;
+            }
+        }
+    }
+
+    else if (coap_packet_ptr->msg_code == COAP_MSG_CODE_RESPONSE_CHANGED) {
+        if (handle->grs->coap->sn_coap_block_data_size > 0) {
+            handle->update_register_msg_id += handle->update_register_msg_len / handle->grs->coap->sn_coap_block_data_size;
+        }
+        if (coap_packet_ptr->msg_id == handle->update_register_msg_id) {
+            is_update_reg_msg = true;
+        }
+    }
+
+    if (coap_packet_ptr->msg_id == handle->unregister_msg_id) {
+        is_unreg_msg = true;
+        if (coap_packet_ptr->msg_code == COAP_MSG_CODE_RESPONSE_DELETED) {
+            if (handle->ep_information_ptr->endpoint_name_ptr) {
+                handle->sn_nsdl_free(handle->ep_information_ptr->endpoint_name_ptr);
+                handle->ep_information_ptr->endpoint_name_ptr = 0;
+                handle->ep_information_ptr->endpoint_name_len = 0;
+            }
+            if (handle->ep_information_ptr->domain_name_ptr) {
+                handle->sn_nsdl_free(handle->ep_information_ptr->domain_name_ptr);
+                handle->ep_information_ptr->domain_name_ptr = 0;
+                handle->ep_information_ptr->domain_name_len = 0;
+            }
+        }
+    }
+
+    /* No messages to wait for, or message was not response to our request */
+    int ret = handle->sn_nsdl_rx_callback(handle, coap_packet_ptr, address_ptr);
+    if (is_reg_msg) {
+        handle->register_msg_id = 0;
+        handle->register_msg_len = 0;
+    }
+    else if (is_unreg_msg) {
+        handle->unregister_msg_id = 0;
+    }
+    else if (is_update_reg_msg) {
+        handle->update_register_msg_id = 0;
+        handle->update_register_msg_len = 0;
+    }
+    return ret;
+}
+
+/**
+ * \fn static int8_t sn_nsdl_resolve_ep_information(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr)
+ *
+ *
+ * \brief Resolves endpoint information from received CoAP message
+ * \param *handle           Pointer to nsdl-library handle
+ * \param *coap_packet_ptr  Pointer to received CoAP message
+ *
+ * \return  SN_NSDL_SUCCESS = 0, Failed = -1
+ */
+static int8_t sn_nsdl_resolve_ep_information(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr)
+{
+    uint8_t     *temp_ptr;
+    uint8_t     parameter_count     = 0;
+    uint16_t    parameter_len       = 0;
+
+    if (!coap_packet_ptr || !coap_packet_ptr->options_list_ptr ||
+        !coap_packet_ptr->options_list_ptr->location_path_ptr) {
+        return SN_NSDL_FAILURE;
+    }
+
+    temp_ptr = coap_packet_ptr->options_list_ptr->location_path_ptr;
+
+    while (temp_ptr <= (coap_packet_ptr->options_list_ptr->location_path_ptr + coap_packet_ptr->options_list_ptr->location_path_len)) {
+
+        if ((temp_ptr == (coap_packet_ptr->options_list_ptr->location_path_ptr + coap_packet_ptr->options_list_ptr->location_path_len)) || (*temp_ptr == '/')) {
+
+            parameter_count++;
+            if (parameter_count == 2) {
+                if (!handle->ep_information_ptr->domain_name_ptr) {
+                    handle->ep_information_ptr->domain_name_len = parameter_len - 1;
+                    handle->ep_information_ptr->domain_name_ptr = handle->sn_nsdl_alloc(handle->ep_information_ptr->domain_name_len);
+                    if (!handle->ep_information_ptr->domain_name_ptr) {
+                        return SN_NSDL_FAILURE;
+                    }
+                    memcpy(handle->ep_information_ptr->domain_name_ptr, temp_ptr - handle->ep_information_ptr->domain_name_len, handle->ep_information_ptr->domain_name_len);
+                }
+
+            }
+            if (parameter_count == 3) {
+                if (!handle->ep_information_ptr->endpoint_name_ptr) {
+                    handle->ep_information_ptr->endpoint_name_len = parameter_len - 1;
+                    handle->ep_information_ptr->endpoint_name_ptr = handle->sn_nsdl_alloc(handle->ep_information_ptr->endpoint_name_len);
+                    if (!handle->ep_information_ptr->endpoint_name_ptr) {
+                        if (handle->ep_information_ptr->domain_name_ptr) {
+                            handle->sn_nsdl_free(handle->ep_information_ptr->domain_name_ptr);
+                            handle->ep_information_ptr->domain_name_ptr = NULL;
+                            handle->ep_information_ptr->domain_name_len = 0;
+                        }
+
+                        return SN_NSDL_FAILURE;
+
+                    }
+                    memcpy(handle->ep_information_ptr->endpoint_name_ptr, temp_ptr - handle->ep_information_ptr->endpoint_name_len, handle->ep_information_ptr->endpoint_name_len);
+                }
+            }
+            parameter_len = 0;
+        }
+        parameter_len++;
+        temp_ptr++;
+    }
+
+
+    return SN_NSDL_SUCCESS;
+}
+
+int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint16_t port, sn_nsdl_addr_type_e address_type)
+{
+
+    /* Check parameters and source pointers */
+    if (!handle || !handle->nsp_address_ptr || !handle->nsp_address_ptr->omalw_address_ptr || !NSP_address) {
+        return SN_NSDL_FAILURE;
+    }
+
+    handle->nsp_address_ptr->omalw_address_ptr->type = address_type;
+    handle->nsp_address_ptr->omalw_server_security = SEC_NOT_SET;
+
+    if (address_type == SN_NSDL_ADDRESS_TYPE_IPV4) {
+        if (handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
+        }
+
+        handle->nsp_address_ptr->omalw_address_ptr->addr_len = 4;
+
+        handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(handle->nsp_address_ptr->omalw_address_ptr->addr_len);
+        if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+            return SN_NSDL_FAILURE;
+        }
+
+        memcpy(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, NSP_address, handle->nsp_address_ptr->omalw_address_ptr->addr_len);
+        handle->nsp_address_ptr->omalw_address_ptr->port = port;
+    }
+
+    else if (address_type == SN_NSDL_ADDRESS_TYPE_IPV6) {
+        if (handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
+        }
+
+        handle->nsp_address_ptr->omalw_address_ptr->addr_len = 16;
+
+        handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(handle->nsp_address_ptr->omalw_address_ptr->addr_len);
+        if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+            return SN_NSDL_FAILURE;
+        }
+
+        memcpy(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, NSP_address, handle->nsp_address_ptr->omalw_address_ptr->addr_len);
+        handle->nsp_address_ptr->omalw_address_ptr->port = port;
+    }
+    return SN_NSDL_SUCCESS;
+}
+
+extern int8_t set_NSP_address_2(struct nsdl_s *handle, uint8_t *NSP_address, uint8_t address_length, uint16_t port, sn_nsdl_addr_type_e address_type)
+{
+    /* Check parameters and source pointers */
+    if (!handle || !handle->nsp_address_ptr || !handle->nsp_address_ptr->omalw_address_ptr || !NSP_address) {
+        return SN_NSDL_FAILURE;
+    }
+
+    handle->nsp_address_ptr->omalw_address_ptr->type = address_type;
+    handle->nsp_address_ptr->omalw_server_security = SEC_NOT_SET;
+
+    if (handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+        handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
+    }
+
+    handle->nsp_address_ptr->omalw_address_ptr->addr_len = address_length;
+
+    handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(handle->nsp_address_ptr->omalw_address_ptr->addr_len);
+    if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+        return SN_NSDL_FAILURE;
+    }
+
+    memcpy(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, NSP_address, handle->nsp_address_ptr->omalw_address_ptr->addr_len);
+    handle->nsp_address_ptr->omalw_address_ptr->port = port;
+
+    return SN_NSDL_SUCCESS;
+}
+
+
+static uint8_t sn_nsdl_itoa_len(uint8_t value)
+{
+    uint8_t i = 0;
+
+    do {
+        i++;
+    } while ((value /= 10) > 0);
+
+    return i;
+}
+
+static uint8_t *sn_nsdl_itoa(uint8_t *ptr, uint8_t value)
+{
+
+    uint8_t start = 0;
+    uint8_t end = 0;
+    uint8_t i;
+
+    i = 0;
+
+    /* ITOA */
+    do {
+        ptr[i++] = (value % 10) + '0';
+    } while ((value /= 10) > 0);
+
+    end = i - 1;
+
+    /* reverse (part of ITOA) */
+    while (start < end) {
+        uint8_t chr;
+
+        chr = ptr[start];
+        ptr[start] = ptr[end];
+        ptr[end] = chr;
+
+        start++;
+        end--;
+
+    }
+    return (ptr + i);
+}
+
+static int32_t sn_nsdl_atoi(uint8_t *ptr, uint8_t len)
+{
+
+    int32_t result = 0;
+
+    while (len--) {
+
+        if (result) {
+            result *= 10;
+        }
+
+        if (*ptr >= '0' && *ptr <= '9') {
+            result += *ptr - '0';
+        } else{
+            return -1;
+        }
+
+        ptr++;
+
+    }
+    return result;
+
+}
+
+static uint32_t sn_nsdl_ahextoi(uint8_t *ptr, uint8_t len)
+{
+
+    uint32_t result = 0;
+
+    while (len--) {
+
+        if (result) {
+            result *= 16;
+        }
+
+        if (*ptr >= '0' && *ptr <= '9') {
+            result += *ptr - '0';
+        } else if (*ptr >= 'a' && *ptr <= 'f') {
+            result += *ptr - 87;
+        } else if (*ptr >= 'A' && *ptr <= 'F') {
+            result += *ptr - 55;
+        }
+
+        ptr++;
+
+    }
+    return result;
+
+}
+
+static int8_t sn_nsdl_resolve_lwm2m_address(struct nsdl_s *handle, uint8_t *uri, uint16_t uri_len)
+{
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    if( uri_len < 2 ){
+        return SN_NSDL_FAILURE;
+    }
+    uint8_t *temp_ptr = uri+2;
+    uint16_t i = 0;
+    uint8_t char_cnt = 0;
+
+    /* jump over coap// */
+    while ((*(temp_ptr - 2) != '/') || (*(temp_ptr - 1) != '/')) {
+        temp_ptr++;
+        if (temp_ptr - uri >= uri_len) {
+            return SN_NSDL_FAILURE;
+        }
+    }
+
+    /* Resolve address type */
+    /* Count semicolons */
+
+    int8_t endPos = -1;
+
+    while (i < (uri_len - (temp_ptr - uri))) {
+        if (*(temp_ptr + i) == ':') {
+            char_cnt++;
+        }else if(*(temp_ptr + i) == ']'){
+            endPos = i;
+        }
+        i++;
+    }
+
+    uint8_t *temp_pos = temp_ptr; //store starting point in case of IPv4 parsing fails
+
+    /* IPv6 */
+    if (char_cnt > 2) {
+        i = 0;
+
+        if( handle->nsp_address_ptr->omalw_address_ptr->addr_ptr ){
+            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
+        }
+
+        handle->nsp_address_ptr->omalw_address_ptr->type = SN_NSDL_ADDRESS_TYPE_IPV6;
+        handle->nsp_address_ptr->omalw_address_ptr->addr_len = 16;
+        handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(16);
+        if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+            return SN_NSDL_FAILURE;
+        }
+
+        memset(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, 0, 16);
+        if (*temp_ptr == '[' && endPos > 0 && (temp_ptr - uri) + endPos < uri_len && *(temp_ptr + endPos + 1) == ':') {
+            temp_ptr++;
+            endPos--;
+        }else{
+            /* return failure, because port is mandatory */
+            return SN_NSDL_FAILURE;
+        }
+
+        int8_t loopbackPos = -1;
+        if( char_cnt != 8 ){
+            i = 0;
+            char_cnt -= 1;
+            while( i+1 < endPos ){
+                if(*(temp_ptr + i) == ':' && *(temp_ptr + i+1) == ':') {
+                    loopbackPos = i;
+                    break;
+                }
+                i++;
+            }
+        }
+        i = 0;
+
+        uint8_t numberOfZeros = 8 - char_cnt;
+        if(loopbackPos == 0){
+            numberOfZeros++;
+        }
+
+        if(loopbackPos == endPos-2){
+            numberOfZeros++;
+        }
+
+        /* Resolve address */
+        int8_t pos = loopbackPos == 0?0:-1;
+        while (i < 16 && ((temp_ptr - uri) + char_cnt) < uri_len) {
+            char_cnt = 0;
+            if( pos == loopbackPos ){
+                for( int k=0; k < numberOfZeros; k++ ){
+                    i+=2;
+                }
+                pos+=2;
+                temp_ptr += 2;
+                if( numberOfZeros == 8 ){
+                    temp_ptr++;
+                }
+                continue;
+            }
+            while (*(temp_ptr + char_cnt) != ':' && *(temp_ptr + char_cnt) != ']') {
+                char_cnt++;
+                pos++;
+            }
+            pos++;
+
+            if (char_cnt <= 2) {
+                i++;
+            }
+
+            while (char_cnt) {
+                if (char_cnt % 2) {
+                    *(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr + i) = (uint8_t)sn_nsdl_ahextoi(temp_ptr, 1);
+                    temp_ptr++;
+                    char_cnt --;
+                } else {
+                    *(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr + i) = (uint8_t)sn_nsdl_ahextoi(temp_ptr, 2);
+                    temp_ptr += 2;
+                    char_cnt -= 2;
+                }
+                i++;
+            }
+            temp_ptr++;
+        }
+
+        temp_ptr++;
+        uint16_t handled = (temp_ptr - uri);
+        if( handled < uri_len ){
+            if( *(temp_ptr + (uri_len - (temp_ptr - uri) -1)) == '/' ){
+                handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri) - 1);
+            }else{
+                handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri));
+            }
+        }
+    }
+    /* IPv4 or Hostname */
+    else if (char_cnt == 1) {
+        char_cnt = 0;
+        i = 0;
+
+        if( handle->nsp_address_ptr->omalw_address_ptr->addr_ptr ){
+            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
+        }
+
+        /* Check address type */
+        while (i < (uri_len - (temp_ptr - uri))) {
+            if (*(temp_ptr + i) == '.') {
+                char_cnt++;
+            }
+            i++;
+        }
+
+        bool parseOk = true;
+
+        /* Try IPv4 first */
+        if (char_cnt == 3) {
+            i = 0;
+            char_cnt = 0;
+
+            handle->nsp_address_ptr->omalw_address_ptr->type = SN_NSDL_ADDRESS_TYPE_IPV4;
+            handle->nsp_address_ptr->omalw_address_ptr->addr_len = 4;
+            handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(4);
+            if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+                return SN_NSDL_FAILURE;
+            }
+
+            while (parseOk && ((temp_ptr - uri) < uri_len) && *(temp_ptr - 1) != ':') {
+                i++;
+
+                if (*(temp_ptr + i) == ':' || *(temp_ptr + i) == '.') {
+                    int8_t value = (int8_t)sn_nsdl_atoi(temp_ptr, i);
+                    if( value == -1 ){
+                        parseOk = false;
+                        char_cnt = 3;
+                        handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
+                        handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = NULL;
+                        break;
+                    }
+                    *(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr + char_cnt) = value;
+                    temp_ptr = temp_ptr + i + 1;
+                    char_cnt++;
+                    i = 0;
+                }
+            }
+            if(parseOk) {
+                if( *(temp_ptr + (uri_len - (temp_ptr - uri) -1)) == '/' ){
+                    handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri) - 1);
+                }else{
+                    handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri));
+                }
+            }
+        }else{
+            parseOk = false;
+        }
+
+        /* Then try Hostname */
+        if(!parseOk) {
+            i = 0;
+            temp_ptr = temp_pos;
+
+            handle->nsp_address_ptr->omalw_address_ptr->type = SN_NSDL_ADDRESS_TYPE_HOSTNAME;
+
+            /* Resolve address length */
+            if (uri_len > 0xff) {
+                return SN_NSDL_FAILURE;
+            }
+
+            while (((temp_ptr - uri) + i < uri_len) && *(temp_ptr + i) != ':') {
+                i++;
+            }
+
+            handle->nsp_address_ptr->omalw_address_ptr->addr_len = i;
+
+            /* Copy address */
+            handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(i);
+            if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
+                return SN_NSDL_FAILURE;
+            }
+
+            memcpy(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, temp_ptr, i);
+
+            temp_ptr += i + 1;
+
+            /* Set port */
+            if( *(temp_ptr + (uri_len - (temp_ptr - uri) - 1)) == '/' ){
+                handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri) - 1);
+            }else{
+                handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri));
+            }
+        }
+    } else {
+        return SN_NSDL_FAILURE;
+    }
+
+    return SN_NSDL_SUCCESS;
+#else
+    return SN_NSDL_FAILURE;
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+}
+
+
+int8_t sn_nsdl_process_oma_tlv(struct nsdl_s *handle, uint8_t *data_ptr, uint16_t data_len)
+{
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    uint8_t *temp_ptr = data_ptr;
+    uint8_t type = 0;
+    uint16_t identifier = 0;
+    uint32_t length = 0;
+    uint8_t path_temp[5] = "0/0/x";
+
+    sn_nsdl_resource_info_s resource_temp = {
+        .resource_parameters_ptr = 0,
+        .mode = SN_GRS_STATIC,
+        .pathlen = 5,
+        .path = path_temp,
+        .resourcelen = 0,
+        .resource = 0,
+        .access = (sn_grs_resource_acl_e) 0x0f, /* All allowed */
+        .sn_grs_dyn_res_callback = 0
+    };
+
+    while ((temp_ptr - data_ptr) < data_len) {
+        /* Save type for future use */
+        type = *temp_ptr++;
+
+        /* * Bit 5: Indicates the Length of the Identifier. * */
+        if (type & 0x20) {
+            /* 1=The Identifier field of this TLV is 16 bits long */
+            identifier = (uint8_t)(*temp_ptr++) << 8;
+            identifier += (uint8_t) * temp_ptr++;
+        } else {
+            /* 0=The Identifier field of this TLV is 8 bits long */
+            identifier = (uint8_t) * temp_ptr++;
+        }
+
+        /* * Bit 4-3: Indicates the type of Length. * */
+        if ((type & 0x18) == 0) {
+            /* 00 = No length field, the value immediately follows the Identifier field in is of the length indicated by Bits 2-0 of this field */
+            length = (type & 0x07);
+        } else if ((type & 0x18) == 0x08) {
+            /* 01 = The Length field is 8-bits and Bits 2-0 MUST be ignored */
+            length = *temp_ptr++;
+        } else if ((type & 0x18) == 0x10) {
+            /* 10 = The Length field is 16-bits and Bits 2-0 MUST be ignored */
+            length = (uint8_t)(*temp_ptr++) << 8;
+            length += (uint8_t) * temp_ptr++;
+        } else if ((type & 0x18) == 0x18) {
+            /* 11 = The Length field is 24-bits and Bits 2-0 MUST be ignored */
+            length = (uint8_t)(*temp_ptr++);
+            length = length << 16;
+            length += (uint8_t)(*temp_ptr++) << 8;
+            length += (uint8_t) * temp_ptr++;
+        }
+
+        /* * Bits 7-6: Indicates the type of Identifier. * */
+        if ((type & 0xC0) == 0x00) {
+            /* 00 = Object Instance in which case the Value contains one or more Resource TLVs */
+            /* Not implemented, return failure */
+        } else if ((type & 0xC0) == 0xC0) {
+            /* 11 = Resource with Value */
+            switch (identifier) {
+                case 0:
+                    /* Resolve LWM2M Server URI */
+                    sn_nsdl_resolve_lwm2m_address(handle, temp_ptr, length);
+                    path_temp[4] = '0';
+                    resource_temp.resource = temp_ptr;
+                    resource_temp.resourcelen = length;
+                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
+                        return SN_NSDL_FAILURE;
+                    }
+                    break;
+                case 2:
+                    /* Resolve security Mode */
+                    handle->nsp_address_ptr->omalw_server_security = (omalw_server_security_t)sn_nsdl_atoi(temp_ptr, length);
+                    path_temp[4] = '2';
+                    resource_temp.resource = temp_ptr;
+                    resource_temp.resourcelen = length;
+                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
+                        return SN_NSDL_FAILURE;
+                    }
+
+                    break;
+                case 3:
+                    /* Public Key or Identity */
+                    path_temp[4] = '3';
+                    resource_temp.resource = temp_ptr;
+                    resource_temp.resourcelen = length;
+                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
+                        return SN_NSDL_FAILURE;
+                    }
+                    break;
+                case 4:
+                    /* Server Public Key or Identity */
+                    ;
+                    path_temp[4] = '4';
+                    resource_temp.resource = temp_ptr;
+                    resource_temp.resourcelen = length;
+                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
+                        return SN_NSDL_FAILURE;
+                    }
+
+                    break;
+                case 5:
+                    /* Secret Key */
+                    path_temp[4] = '5';
+                    resource_temp.resource = temp_ptr;
+                    resource_temp.resourcelen = length;
+                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
+                        return SN_NSDL_FAILURE;
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            /* Move pointer to next TLV message */
+            temp_ptr += length;
+        }
+    }
+
+    return SN_NSDL_SUCCESS;
+#else
+    return SN_NSDL_FAILURE;
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+}
+
+static void sn_nsdl_check_oma_bs_status(struct nsdl_s *handle)
+{
+#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+    /* Check OMA BS status */
+    if ((handle->nsp_address_ptr->omalw_server_security == PSK) && (handle->nsp_address_ptr->omalw_address_ptr->type != SN_NSDL_ADDRESS_TYPE_NONE)) {
+        /* call cb that oma bootstrap is done */
+        if(handle->sn_nsdl_oma_bs_done_cb != 0){
+            handle->sn_nsdl_oma_bs_done_cb(handle->nsp_address_ptr);
+        }
+        if(handle->sn_nsdl_oma_bs_done_cb_handle != 0){
+            handle->sn_nsdl_oma_bs_done_cb_handle(handle->nsp_address_ptr, handle);
+        }
+
+    } else if ((handle->nsp_address_ptr->omalw_server_security == CERTIFICATE) && (handle->nsp_address_ptr->omalw_address_ptr->type != SN_NSDL_ADDRESS_TYPE_NONE) &&
+               ((sn_nsdl_get_resource(handle, 5, (void *)"0/0/5") != 0) &&
+                (sn_nsdl_get_resource(handle, 5, (void *)"0/0/4") != 0) &&
+                (sn_nsdl_get_resource(handle, 5, (void *)"0/0/3") != 0))) {
+        if( handle->sn_nsdl_oma_bs_done_cb ){
+            handle->sn_nsdl_oma_bs_done_cb(handle->nsp_address_ptr);
+        }
+        if( handle->sn_nsdl_oma_bs_done_cb_handle ){
+            handle->sn_nsdl_oma_bs_done_cb_handle(handle->nsp_address_ptr, handle);
+        }
+    }
+#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
+}
+
+static int8_t set_endpoint_info(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *endpoint_info_ptr)
+{
+    if (handle->ep_information_ptr->domain_name_ptr) {
+        handle->sn_nsdl_free(handle->ep_information_ptr->domain_name_ptr);
+        handle->ep_information_ptr->domain_name_ptr = 0;
+        handle->ep_information_ptr->domain_name_len = 0;
+    }
+
+    if (handle->ep_information_ptr->endpoint_name_ptr) {
+        handle->sn_nsdl_free(handle->ep_information_ptr->endpoint_name_ptr);
+        handle->ep_information_ptr->endpoint_name_ptr = 0;
+        handle->ep_information_ptr->endpoint_name_len = 0;
+    }
+
+    if (endpoint_info_ptr->domain_name_ptr && endpoint_info_ptr->domain_name_len) {
+        handle->ep_information_ptr->domain_name_ptr = handle->sn_nsdl_alloc(endpoint_info_ptr->domain_name_len);
+
+        if (!handle->ep_information_ptr->domain_name_ptr) {
+            return -1;
+        }
+
+        memcpy(handle->ep_information_ptr->domain_name_ptr, endpoint_info_ptr->domain_name_ptr, endpoint_info_ptr->domain_name_len);
+        handle->ep_information_ptr->domain_name_len = endpoint_info_ptr->domain_name_len;
+    }
+
+    if (endpoint_info_ptr->endpoint_name_ptr && endpoint_info_ptr->endpoint_name_len) {
+        handle->ep_information_ptr->endpoint_name_ptr = handle->sn_nsdl_alloc(endpoint_info_ptr->endpoint_name_len);
+
+        if (!handle->ep_information_ptr->endpoint_name_ptr) {
+            if (handle->ep_information_ptr->domain_name_ptr) {
+                handle->sn_nsdl_free(handle->ep_information_ptr->domain_name_ptr);
+                handle->ep_information_ptr->domain_name_ptr = 0;
+                handle->ep_information_ptr->domain_name_len = 0;
+            }
+            return -1;
+        }
+
+        memcpy(handle->ep_information_ptr->endpoint_name_ptr, endpoint_info_ptr->endpoint_name_ptr, endpoint_info_ptr->endpoint_name_len);
+        handle->ep_information_ptr->endpoint_name_len = endpoint_info_ptr->endpoint_name_len;
+    }
+
+    handle->ep_information_ptr->binding_and_mode = endpoint_info_ptr->binding_and_mode;
+    handle->ep_information_ptr->ds_register_mode = endpoint_info_ptr->ds_register_mode;
+
+    handle->ep_information_ptr->location_ptr = 0;
+    handle->ep_information_ptr->location_len = 0;
+
+    return 0;
+}
+
+/* Wrapper */
+sn_grs_resource_list_s *sn_nsdl_list_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    return sn_grs_list_resource(handle->grs, pathlen, path);
+}
+
+void sn_nsdl_free_resource_list(struct nsdl_s *handle, sn_grs_resource_list_s *list)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return;
+    }
+
+    sn_grs_free_resource_list(handle->grs, list);
+}
+
+extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return sn_grs_update_resource(handle->grs, res);
+}
+
+extern int8_t sn_nsdl_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *address_ptr, sn_coap_hdr_s *coap_hdr_ptr)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return sn_grs_send_coap_message(handle, address_ptr, coap_hdr_ptr);
+}
+
+extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return sn_grs_create_resource(handle->grs, res);
+}
+
+extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res)
+{
+    if (!handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return sn_grs_put_resource(handle->grs, res);
+}
+
+extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return sn_grs_delete_resource(handle->grs, pathlen, path);
+}
+extern const sn_nsdl_resource_info_s *sn_nsdl_get_first_resource(struct nsdl_s *handle)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    return sn_grs_get_first_resource(handle->grs);
+}
+extern const sn_nsdl_resource_info_s *sn_nsdl_get_next_resource(struct nsdl_s *handle, const sn_nsdl_resource_info_s *resource)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    return sn_grs_get_next_resource(handle->grs, resource);
+}
+
+extern sn_coap_hdr_s *sn_nsdl_build_response(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr, uint8_t msg_code)
+{
+    if (handle == NULL) {
+        return NULL;
+    }
+
+    return sn_coap_build_response(handle->grs->coap, coap_packet_ptr, msg_code);
+}
+
+extern sn_coap_options_list_s *sn_nsdl_alloc_options_list(struct nsdl_s *handle, sn_coap_hdr_s *coap_msg_ptr)
+{
+    if (handle == NULL || coap_msg_ptr == NULL) {
+        return NULL;
+    }
+    return sn_coap_parser_alloc_options(handle->grs->coap, coap_msg_ptr);
+}
+
+extern void sn_nsdl_release_allocated_coap_msg_mem(struct nsdl_s *handle, sn_coap_hdr_s *freed_coap_msg_ptr)
+{
+    if (handle == NULL) {
+        return;
+    }
+
+    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, freed_coap_msg_ptr);
+}
+
+extern int8_t sn_nsdl_set_retransmission_parameters(struct nsdl_s *handle,
+    uint8_t resending_count, uint8_t resending_interval)
+{
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+    return sn_coap_protocol_set_retransmission_parameters(handle->grs->coap,
+                                                          resending_count,resending_interval);
+}
+
+extern int8_t sn_nsdl_set_retransmission_buffer(struct nsdl_s *handle,
+        uint8_t buffer_size_messages, uint16_t buffer_size_bytes)
+{
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+    return sn_coap_protocol_set_retransmission_buffer(handle->grs->coap,
+                                                      buffer_size_messages, buffer_size_bytes);
+}
+
+extern int8_t sn_nsdl_set_block_size(struct nsdl_s *handle, uint16_t block_size)
+{
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+    return sn_coap_protocol_set_block_size(handle->grs->coap, block_size);
+}
+
+extern int8_t sn_nsdl_set_duplicate_buffer_size(struct nsdl_s *handle, uint8_t message_count)
+{
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+    return sn_coap_protocol_set_duplicate_buffer_size(handle->grs->coap, message_count);
+}
+
+bool sn_nsdl_check_uint_overflow(uint16_t resource_size, uint16_t param_a, uint16_t param_b)
+{
+    uint16_t first_check = param_a + param_b;
+    if (first_check < param_b) {
+        return false;
+    } else {
+        uint16_t total = resource_size + first_check;
+        if (total < first_check) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}
+
+extern int8_t sn_nsdl_set_context(struct nsdl_s * const handle, void * const context)
+{
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+    handle->context = context;
+    return SN_NSDL_SUCCESS;
+}
+
+extern void *sn_nsdl_get_context(const struct nsdl_s * const handle)
+{
+    if (handle == NULL) {
+        return NULL;
+    }
+    return handle->context;
+}

--- a/source/libNsdl/src/sn_nsdl2.c
+++ b/source/libNsdl/src/sn_nsdl2.c
@@ -77,7 +77,6 @@ static uint8_t      resource_type_parameter[]   = {'r', 't', '='};      /* Resou
 #ifndef COAP_DISABLE_OBS_FEATURE
 static uint8_t      obs_parameter[]             = {'o', 'b', 's'};      /* Observable */
 #endif
-//static uint8_t    aobs_parameter[]            = {'a','o','b','s',';','i','d','='};    /* Auto-observable - TBD */
 static uint8_t      if_description_parameter[]  = {'i', 'f', '='};      /* Interface description. Only once */
 static uint8_t      ep_lifetime_parameter[]     = {'l', 't', '='};      /* Lifetime. Number of seconds that this registration will be valid for. Must be updated within this time, or will be removed. */
 static uint8_t      ep_domain_parameter[]       = {'d', '='};           /* Domain name. If this parameter is missing, a default domain is assumed. */
@@ -99,12 +98,6 @@ static int8_t           sn_nsdl_local_rx_function(struct nsdl_s *handle, sn_coap
 static int8_t           sn_nsdl_resolve_ep_information(struct nsdl_s *handle, sn_coap_hdr_s *coap_packet_ptr);
 static uint8_t          sn_nsdl_itoa_len(uint8_t value);
 static uint8_t          *sn_nsdl_itoa(uint8_t *ptr, uint8_t value);
-static int32_t          sn_nsdl_atoi(uint8_t *ptr, uint8_t len);
-static uint32_t         sn_nsdl_ahextoi(uint8_t *ptr, uint8_t len);
-static int8_t           sn_nsdl_resolve_lwm2m_address(struct nsdl_s *handle, uint8_t *uri, uint16_t uri_len);
-static int8_t           sn_nsdl_process_oma_tlv(struct nsdl_s *handle, uint8_t *data_ptr, uint16_t data_len);
-static void             sn_nsdl_check_oma_bs_status(struct nsdl_s *handle);
-static int8_t           sn_nsdl_create_oma_device_object_base(struct nsdl_s *handle, sn_nsdl_oma_device_t *oma_device_setup_ptr, sn_nsdl_oma_binding_and_mode_t binding_and_mode);
 static int8_t           set_endpoint_info(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *endpoint_info_ptr);
 static bool             validateParameters(sn_nsdl_ep_parameters_s *parameter_ptr);
 static bool             validate(uint8_t* ptr, uint32_t len, char illegalChar);
@@ -221,8 +214,6 @@ struct nsdl_s *sn_nsdl_init(uint8_t (*sn_nsdl_tx_cb)(struct nsdl_s *, sn_nsdl_ca
     sn_nsdl_resolve_nsp_address(handle);
 
     handle->sn_nsdl_endpoint_registered = SN_NSDL_ENDPOINT_NOT_REGISTERED;
-    // By default bootstrap msgs are handled in nsdl
-    handle->handle_bootstrap_msg = true;
     handle->context = NULL;
 
     return handle;
@@ -515,27 +506,8 @@ int8_t sn_nsdl_is_ep_registered(struct nsdl_s *handle)
 }
 
 uint16_t sn_nsdl_send_observation_notification(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
-        uint8_t *payload_ptr, uint16_t payload_len,
-        sn_coap_observe_e observe,
-        sn_coap_msg_type_e message_type, sn_coap_content_format_e content_format)
-{
-    return sn_nsdl_send_observation_notification_with_uri_path(handle,
-                                                               token_ptr,
-                                                               token_len,
-                                                               payload_ptr,
-                                                               payload_len,
-                                                               observe,
-                                                               message_type,
-                                                               content_format,
-                                                               NULL,
-                                                               0);
-}
-
-uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *handle, uint8_t *token_ptr, uint8_t token_len,
-        uint8_t *payload_ptr, uint16_t payload_len,
-        sn_coap_observe_e observe,
-        sn_coap_msg_type_e message_type, uint8_t content_format,
-        uint8_t *uri_path_ptr, uint16_t uri_path_len)
+   uint8_t *payload_ptr, uint16_t payload_len, sn_coap_observe_e observe, sn_coap_msg_type_e message_type,
+   sn_coap_content_format_e content_format)
 {
     sn_coap_hdr_s   *notification_message_ptr;
     uint16_t        return_msg_id = 0;
@@ -568,10 +540,6 @@ uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *hand
     notification_message_ptr->payload_len = payload_len;
     notification_message_ptr->payload_ptr = payload_ptr;
 
-    /* Fill uri path */
-    notification_message_ptr->uri_path_len = uri_path_len;
-    notification_message_ptr->uri_path_ptr = uri_path_ptr;
-
     /* Fill observe */
     notification_message_ptr->options_list_ptr->observe = observe;
 
@@ -586,7 +554,6 @@ uint16_t sn_nsdl_send_observation_notification_with_uri_path(struct nsdl_s *hand
     }
 
     /* Free memory */
-    notification_message_ptr->uri_path_ptr = NULL;
     notification_message_ptr->payload_ptr = NULL;
     notification_message_ptr->token_ptr = NULL;
 
@@ -614,16 +581,9 @@ uint16_t sn_nsdl_oma_bootstrap(struct nsdl_s *handle, sn_nsdl_addr_s *bootstrap_
     if (!bootstrap_address_ptr || !bootstrap_endpoint_info_ptr || !endpoint_info_ptr || !handle) {
         return 0;
     }
-    /* Create device object */
-    if (handle->handle_bootstrap_msg) {
-        if (sn_nsdl_create_oma_device_object_base(handle, bootstrap_endpoint_info_ptr->device_object, endpoint_info_ptr->binding_and_mode) < 0) {
-            return 0;
-        }
 
-        handle->sn_nsdl_oma_bs_done_cb = bootstrap_endpoint_info_ptr->oma_bs_status_cb;
-        handle->sn_nsdl_oma_bs_done_cb_handle = bootstrap_endpoint_info_ptr->oma_bs_status_cb_handle;
-    }
-
+    handle->sn_nsdl_oma_bs_done_cb = bootstrap_endpoint_info_ptr->oma_bs_status_cb;
+    handle->sn_nsdl_oma_bs_done_cb_handle = bootstrap_endpoint_info_ptr->oma_bs_status_cb_handle;
 
     /* XXX FIX -- Init CoAP header struct */
     sn_coap_parser_init_message(&bootstrap_coap_header);
@@ -676,185 +636,6 @@ uint16_t sn_nsdl_oma_bootstrap(struct nsdl_s *handle, sn_nsdl_addr_s *bootstrap_
 
 }
 
-omalw_certificate_list_t *sn_nsdl_get_certificates(struct nsdl_s *handle)
-{
-#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-    sn_nsdl_resource_info_s *resource_ptr = 0;;
-    omalw_certificate_list_t *certi_list_ptr = 0;
-
-    /* Check parameters */
-    if (handle == NULL) {
-        return NULL;
-    }
-
-    certi_list_ptr = handle->sn_nsdl_alloc(sizeof(omalw_certificate_list_t));
-
-    if (!certi_list_ptr) {
-        return NULL;
-    }
-
-    /* Get private key resource */
-    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/5");
-    if (!resource_ptr) {
-        handle->sn_nsdl_free(certi_list_ptr);
-        return NULL;
-    }
-    certi_list_ptr->own_private_key_ptr = resource_ptr->resource;
-    certi_list_ptr->own_private_key_len = resource_ptr->resourcelen;
-
-    /* Get client certificate resource */
-    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/4");
-    if (!resource_ptr) {
-        handle->sn_nsdl_free(certi_list_ptr);
-        return NULL;
-    }
-    certi_list_ptr->certificate_ptr[0] = resource_ptr->resource;
-    certi_list_ptr->certificate_len[0] = resource_ptr->resourcelen;
-
-    /* Get root certificate resource */
-    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/3");
-    if (!resource_ptr) {
-        handle->sn_nsdl_free(certi_list_ptr);
-        return NULL;
-    }
-    certi_list_ptr->certificate_ptr[1] = resource_ptr->resource;
-    certi_list_ptr->certificate_len[1] = resource_ptr->resourcelen;
-
-    /* return filled list */
-    return certi_list_ptr;
-#else
-    return NULL;
-#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-}
-
-int8_t sn_nsdl_update_certificates(struct nsdl_s *handle, omalw_certificate_list_t *certificate_ptr, uint8_t certificate_chain)
-{
-#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-    (void)certificate_chain;
-
-    /* Check pointers */
-    if (!certificate_ptr || !handle) {
-        return SN_NSDL_FAILURE;
-    }
-
-    sn_nsdl_resource_info_s *resource_ptr = 0;;
-
-    /* Get private key resource */
-    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/5");
-    if (!resource_ptr) {
-        return SN_NSDL_FAILURE;
-    }
-    handle->sn_nsdl_free(resource_ptr->resource);
-    resource_ptr->resource = certificate_ptr->own_private_key_ptr;
-    resource_ptr->resourcelen = certificate_ptr->own_private_key_len;
-
-    /* Get client certificate resource */
-    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/4");
-    if (!resource_ptr) {
-        return SN_NSDL_FAILURE;
-    }
-    handle->sn_nsdl_free(resource_ptr->resource);
-    resource_ptr->resource = certificate_ptr->certificate_ptr[0];
-    resource_ptr->resourcelen = certificate_ptr->certificate_len[0];
-
-    /* Get root certificate resource */
-    resource_ptr = sn_nsdl_get_resource(handle, 5, (void *)"0/0/3");
-    if (!resource_ptr) {
-        return SN_NSDL_FAILURE;
-    }
-    handle->sn_nsdl_free(resource_ptr->resource);
-    resource_ptr->resource = certificate_ptr->certificate_ptr[1];
-    resource_ptr->resourcelen = certificate_ptr->certificate_len[1];
-
-    return SN_NSDL_SUCCESS;
-#else
-    return SN_NSDL_FAILURE;
-#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-}
-
-int8_t sn_nsdl_create_oma_device_object(struct nsdl_s *handle, sn_nsdl_oma_device_t *device_object_ptr)
-{
-#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-    sn_nsdl_resource_info_s *resource_temp = 0;
-    uint8_t path[8] = "3/0/11/0";
-
-    if (!device_object_ptr || !handle) {
-        return SN_NSDL_FAILURE;
-    }
-
-    /* * Error code * */
-
-    /* Get first error message */
-    resource_temp = sn_grs_search_resource(handle->grs, 8, path, SN_GRS_SEARCH_METHOD);
-
-    while (resource_temp) {
-        if (resource_temp->resource) {
-            /* If no error code set */
-            if (*resource_temp->resource == 0) {
-                /* Set error code */
-                *resource_temp->resource = (uint8_t)device_object_ptr->error_code;
-                resource_temp->resourcelen = 1;
-
-                sn_nsdl_update_resource(handle, resource_temp);
-                return SN_NSDL_SUCCESS;
-            }
-            break;
-        }
-
-        if (path[7] == '9') {
-            return SN_NSDL_FAILURE;
-        }
-
-        path[7]++;
-        resource_temp = sn_grs_search_resource(handle->grs, 8, path, SN_GRS_SEARCH_METHOD);
-    }
-
-    /* Create new resource for this error */
-    resource_temp = handle->sn_nsdl_alloc(sizeof(sn_nsdl_resource_info_s));
-    if (!resource_temp) {
-        return SN_NSDL_FAILURE;
-    }
-
-    memset(resource_temp, 0, sizeof(sn_nsdl_resource_info_s));
-
-    resource_temp->access = SN_GRS_GET_ALLOWED;
-    resource_temp->mode = SN_GRS_DYNAMIC;
-
-    resource_temp->path = path;
-    resource_temp->pathlen = 8;
-
-    resource_temp->resource = handle->sn_nsdl_alloc(1);
-    if (!resource_temp->resource) {
-        handle->sn_nsdl_free(resource_temp);
-        return SN_NSDL_FAILURE;
-    }
-
-    *resource_temp->resource = (uint8_t)device_object_ptr->error_code;
-    resource_temp->resourcelen = 1;
-
-    resource_temp->resource_parameters_ptr = handle->sn_nsdl_alloc(sizeof(sn_nsdl_resource_parameters_s));
-
-    if (!resource_temp->resource_parameters_ptr) {
-        handle->sn_nsdl_free(resource_temp->resource);
-        handle->sn_nsdl_free(resource_temp);
-
-        return SN_NSDL_FAILURE;
-    }
-
-    memset(resource_temp->resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
-
-    sn_nsdl_create_resource(handle, resource_temp);
-
-    handle->sn_nsdl_free(resource_temp->resource);
-    handle->sn_nsdl_free(resource_temp->resource_parameters_ptr);
-    handle->sn_nsdl_free(resource_temp);
-
-    return SN_NSDL_SUCCESS;
-#else
-    return SN_NSDL_FAILURE;
-#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-}
-
 char *sn_nsdl_get_version(void)
 {
 #if defined(YOTTA_MBED_CLIENT_C_VERSION_STRING)
@@ -866,12 +647,11 @@ char *sn_nsdl_get_version(void)
 #endif
 }
 
-
 int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet_ptr, uint16_t packet_len, sn_nsdl_addr_s *src_ptr)
 {
     sn_coap_hdr_s           *coap_packet_ptr    = NULL;
     sn_coap_hdr_s           *coap_response_ptr  = NULL;
-    sn_nsdl_resource_info_s *resource = NULL;
+    sn_nsdl_dynamic_resource_parameters_s *resource = NULL;
     /* Check parameters */
     if (handle == NULL) {
         return SN_NSDL_FAILURE;
@@ -888,7 +668,7 @@ int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet_ptr, uint16_t
     // Pass block to application if external_memory_block is set
     if(coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVING) {
         resource = sn_nsdl_get_resource(handle, coap_packet_ptr->uri_path_len, coap_packet_ptr->uri_path_ptr);
-        if(resource && resource->external_memory_block) {
+        if(resource && resource->static_resource_parameters->external_memory_block) {
             sn_coap_protocol_block_remove(handle->grs->coap,
                                           src_ptr,
                                           coap_packet_ptr->payload_len,
@@ -926,9 +706,11 @@ int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet_ptr, uint16_t
     /* If message is response message, call RX callback  */
     /* * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-    if ((coap_packet_ptr->msg_code > COAP_MSG_CODE_REQUEST_DELETE) || (coap_packet_ptr->msg_type == COAP_MSG_TYPE_ACKNOWLEDGEMENT)) {
+    if ((coap_packet_ptr->msg_code > COAP_MSG_CODE_REQUEST_DELETE) ||
+            (coap_packet_ptr->msg_type >= COAP_MSG_TYPE_ACKNOWLEDGEMENT)) {
         int8_t retval = sn_nsdl_local_rx_function(handle, coap_packet_ptr, src_ptr);
-        if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED && coap_packet_ptr->payload_ptr) {
+        if (coap_packet_ptr->coap_status == COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED &&
+                coap_packet_ptr->payload_ptr) {
             handle->sn_nsdl_free(coap_packet_ptr->payload_ptr);
             coap_packet_ptr->payload_ptr = 0;
         }
@@ -940,72 +722,11 @@ int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet_ptr, uint16_t
     bool bootstrap_msg = src_ptr && (handle->oma_bs_address_len == src_ptr->addr_len) &&
             (handle->oma_bs_port == src_ptr->port) &&
             !memcmp(handle->oma_bs_address_ptr, src_ptr->addr_ptr, handle->oma_bs_address_len);
+
     // Pass bootstrap data to application
-    if (bootstrap_msg && !handle->handle_bootstrap_msg) {
+    if (bootstrap_msg) {
         handle->sn_nsdl_rx_callback(handle, coap_packet_ptr,src_ptr);
         sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
-        return SN_NSDL_SUCCESS;
-    }
-    // Internal handling
-    else if (bootstrap_msg) {
-        /* TLV message. Parse message and check status of the OMA bootstrap  */
-        /* process. If ok, call cb function and return. Otherwise send error */
-        /* and return failure.                                               */
-
-        if (coap_packet_ptr->content_format == 99) { //todo check message type
-            /* TLV parsing failed. Send response to get non-tlv messages */
-            if (sn_nsdl_process_oma_tlv(handle, coap_packet_ptr->payload_ptr, coap_packet_ptr->payload_len) == SN_NSDL_FAILURE) {
-                coap_response_ptr = sn_coap_build_response(handle->grs->coap, coap_packet_ptr, COAP_MSG_CODE_RESPONSE_NOT_ACCEPTABLE);
-                if (coap_response_ptr) {
-                    sn_nsdl_send_coap_message(handle, src_ptr, coap_response_ptr);
-                    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_response_ptr);
-                } else {
-                    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
-                    return SN_NSDL_FAILURE;
-                }
-            }
-            /* Success TLV parsing */
-            else {
-                coap_response_ptr = sn_coap_build_response(handle->grs->coap, coap_packet_ptr, COAP_MSG_CODE_RESPONSE_CREATED);
-                if (coap_response_ptr) {
-                    sn_nsdl_send_coap_message(handle, src_ptr, coap_response_ptr);
-                    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_response_ptr);
-
-                } else {
-                    sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
-                    return SN_NSDL_FAILURE;
-                }
-                sn_nsdl_check_oma_bs_status(handle);
-            }
-
-            sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
-            return SN_NSDL_SUCCESS;
-        }
-
-        /* Non - TLV message */
-        else if (coap_packet_ptr->content_format == 97) {
-            sn_grs_process_coap(handle, coap_packet_ptr, src_ptr);
-
-            /* Todo: move this copying to sn_nsdl_check_oma_bs_status(), also from TLV parser */
-            /* Security mode */
-            if (*(coap_packet_ptr->uri_path_ptr + (coap_packet_ptr->uri_path_len - 1)) == '2') {
-                handle->nsp_address_ptr->omalw_server_security = (omalw_server_security_t)sn_nsdl_atoi(coap_packet_ptr->payload_ptr, coap_packet_ptr->payload_len);
-                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
-            }
-
-            /* NSP address */
-            else if (*(coap_packet_ptr->uri_path_ptr + (coap_packet_ptr->uri_path_len - 1)) == '0') {
-                sn_nsdl_resolve_lwm2m_address(handle, coap_packet_ptr->payload_ptr, coap_packet_ptr->payload_len);
-                sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
-            }
-
-            sn_nsdl_check_oma_bs_status(handle);
-        } else {
-            sn_coap_parser_release_allocated_coap_msg_mem(handle->grs->coap, coap_packet_ptr);
-            return SN_NSDL_FAILURE;
-        }
-
-
         return SN_NSDL_SUCCESS;
     }
 #endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
@@ -1013,7 +734,6 @@ int8_t sn_nsdl_process_coap(struct nsdl_s *handle, uint8_t *packet_ptr, uint16_t
     /* * * * * * * * * * * * * * * */
     /* Other messages are for GRS  */
     /* * * * * * * * * * * * * * * */
-
     return sn_grs_process_coap(handle, coap_packet_ptr, src_ptr);
 }
 
@@ -1026,7 +746,7 @@ int8_t sn_nsdl_exec(struct nsdl_s *handle, uint32_t time)
     return sn_coap_protocol_exec(handle->grs->coap, time);
 }
 
-sn_nsdl_resource_info_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path_ptr)
+sn_nsdl_dynamic_resource_parameters_s *sn_nsdl_get_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path_ptr)
 {
     /* Check parameters */
     if (handle == NULL) {
@@ -1132,111 +852,6 @@ static void sn_nsdl_resolve_nsp_address(struct nsdl_s *handle)
     }
 }
 
-static int8_t sn_nsdl_create_oma_device_object_base(struct nsdl_s *handle, sn_nsdl_oma_device_t *oma_device_setup_ptr, sn_nsdl_oma_binding_and_mode_t binding_and_mode)
-{
-#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-    sn_nsdl_resource_info_s new_resource;
-    uint8_t object_path[8] = "3/0/11/0";
-    uint8_t resource_temp[3];
-    uint8_t x = 0;
-
-    if (!oma_device_setup_ptr) {
-        return SN_NSDL_FAILURE;
-    }
-
-    /* * Create resources. * */
-
-    /* These resources can be created multiple times. */
-    memset(&new_resource, 0, sizeof(sn_nsdl_resource_info_s));
-    new_resource.resource_parameters_ptr = handle->sn_nsdl_alloc(sizeof(sn_nsdl_resource_parameters_s));
-    if (!new_resource.resource_parameters_ptr) {
-        return SN_NSDL_FAILURE;
-    }
-
-    memset(new_resource.resource_parameters_ptr, 0, sizeof(sn_nsdl_resource_parameters_s));
-
-    /* Create error - resource */
-    new_resource.mode = SN_GRS_STATIC;
-    new_resource.access = SN_GRS_GET_ALLOWED;
-
-    new_resource.path = object_path;
-    new_resource.pathlen = 8;
-
-    sn_nsdl_itoa(resource_temp, (uint8_t)oma_device_setup_ptr->error_code);
-
-    new_resource.resource = resource_temp;
-    new_resource.resourcelen = 1;
-
-    if (sn_nsdl_create_resource(handle, &new_resource) != SN_NSDL_SUCCESS) {
-        handle->sn_nsdl_free(new_resource.resource_parameters_ptr);
-        return SN_NSDL_FAILURE;
-    }
-
-    /* These resources can be only once, during OMA bootstrap.. */
-    /* Create supported binding and modes */
-    object_path[5] = '6';
-    new_resource.path = object_path;
-    new_resource.pathlen = 6;
-
-    if (binding_and_mode & 0x01) {
-        resource_temp[x] = 'U';
-        x++;
-        if (binding_and_mode & 0x02) {
-            resource_temp[x] = 'Q';
-            x++;
-        }
-    }
-    if (binding_and_mode & 0x04) {
-        resource_temp[x] = 'S';
-        x++;
-        if ((binding_and_mode & 0x02) && !(binding_and_mode & 0x01)) {
-            resource_temp[x] = 'Q';
-            x++;
-        }
-    }
-
-    new_resource.resourcelen = x;
-
-    if (new_resource.resourcelen) {
-        new_resource.resource = resource_temp;
-    } else {
-        new_resource.resource = 0;
-    }
-
-
-    if (sn_nsdl_create_resource(handle, &new_resource) != SN_NSDL_SUCCESS) {
-        handle->sn_nsdl_free(new_resource.resource_parameters_ptr);
-        return SN_NSDL_FAILURE;
-    }
-
-
-    /* Create dynamic reboot object */
-    new_resource.mode = SN_GRS_DYNAMIC;
-
-    new_resource.access = SN_GRS_POST_ALLOWED;
-
-    object_path[4] = '4';
-
-    new_resource.path = object_path;
-    new_resource.pathlen = 5;
-
-    new_resource.resourcelen = 0;
-    new_resource.resource = 0;
-
-    new_resource.sn_grs_dyn_res_callback = oma_device_setup_ptr->sn_oma_device_boot_callback;
-
-    if (sn_nsdl_create_resource(handle, &new_resource) != SN_NSDL_SUCCESS) {
-        handle->sn_nsdl_free(new_resource.resource_parameters_ptr);
-        return SN_NSDL_FAILURE;
-    }
-
-    handle->sn_nsdl_free(new_resource.resource_parameters_ptr);
-    return SN_NSDL_SUCCESS;
-#else
-    return SN_NSDL_FAILURE;
-#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-}
-
 /**
  * \fn int8_t sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *message_ptr, uint8_t updating_registeration)
  *
@@ -1251,7 +866,7 @@ int8_t sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *mes
     tr_debug("sn_nsdl_build_registration_body");
     /* Local variables */
     uint8_t                 *temp_ptr;
-    const sn_nsdl_resource_info_s   *resource_temp_ptr;
+    sn_nsdl_dynamic_resource_parameters_s   *resource_temp_ptr;
 
     /* Calculate needed memory and allocate */
     int8_t error = 0;
@@ -1279,12 +894,12 @@ int8_t sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *mes
     /* Loop trough all resources */
     while (resource_temp_ptr) {
         /* if resource needs to be registered */
-        if (resource_temp_ptr->resource_parameters_ptr && resource_temp_ptr->publish_uri) {
-            if (updating_registeration && resource_temp_ptr->resource_parameters_ptr->registered == SN_NDSL_RESOURCE_REGISTERED) {
+        if (resource_temp_ptr->publish_uri) {
+            if (updating_registeration && resource_temp_ptr->registered == SN_NDSL_RESOURCE_REGISTERED) {
                 resource_temp_ptr = sn_grs_get_next_resource(handle->grs, resource_temp_ptr);
                 continue;
             } else {
-                resource_temp_ptr->resource_parameters_ptr->registered = SN_NDSL_RESOURCE_REGISTERED;
+                resource_temp_ptr->registered = SN_NDSL_RESOURCE_REGISTERED;
             }
 
             /* If not first resource, add '.' to separator */
@@ -1294,74 +909,68 @@ int8_t sn_nsdl_build_registration_body(struct nsdl_s *handle, sn_coap_hdr_s *mes
 
             *temp_ptr++ = '<';
             *temp_ptr++ = '/';
-            memcpy(temp_ptr, resource_temp_ptr->path, resource_temp_ptr->pathlen);
-            temp_ptr += resource_temp_ptr->pathlen;
+            memcpy(temp_ptr,
+                   resource_temp_ptr->static_resource_parameters->path,
+                   resource_temp_ptr->static_resource_parameters->pathlen);
+            temp_ptr += resource_temp_ptr->static_resource_parameters->pathlen;
             *temp_ptr++ = '>';
 
             /* Resource attributes */
-            if (resource_temp_ptr->resource_parameters_ptr->resource_type_len) {
+            size_t resource_type_len = 0;
+            if (resource_temp_ptr->static_resource_parameters->resource_type_ptr) {
+                resource_type_len = strlen(resource_temp_ptr->static_resource_parameters->resource_type_ptr);
+            }
+            if (resource_type_len) {
                 *temp_ptr++ = ';';
                 memcpy(temp_ptr, resource_type_parameter, RT_PARAMETER_LEN);
                 temp_ptr += RT_PARAMETER_LEN;
                 *temp_ptr++ = '"';
-                memcpy(temp_ptr, resource_temp_ptr->resource_parameters_ptr->resource_type_ptr, resource_temp_ptr->resource_parameters_ptr->resource_type_len);
-                temp_ptr += resource_temp_ptr->resource_parameters_ptr->resource_type_len;
+                memcpy(temp_ptr,
+                       resource_temp_ptr->static_resource_parameters->resource_type_ptr,
+                       resource_type_len);
+                temp_ptr += resource_type_len;
                 *temp_ptr++ = '"';
             }
 
-            if (resource_temp_ptr->resource_parameters_ptr->interface_description_len) {
+            size_t interface_description_len = 0;
+            if (resource_temp_ptr->static_resource_parameters->interface_description_ptr) {
+                interface_description_len = strlen(resource_temp_ptr->static_resource_parameters->interface_description_ptr);
+            }
+
+            if (interface_description_len) {
                 *temp_ptr++ = ';';
                 memcpy(temp_ptr, if_description_parameter, IF_PARAMETER_LEN);
                 temp_ptr += IF_PARAMETER_LEN;
                 *temp_ptr++ = '"';
-                memcpy(temp_ptr, resource_temp_ptr->resource_parameters_ptr->interface_description_ptr, resource_temp_ptr->resource_parameters_ptr->interface_description_len);
-                temp_ptr += resource_temp_ptr->resource_parameters_ptr->interface_description_len;
+                memcpy(temp_ptr,
+                       resource_temp_ptr->static_resource_parameters->interface_description_ptr,
+                       interface_description_len);
+                temp_ptr += interface_description_len;
                 *temp_ptr++ = '"';
             }
 
-            if (resource_temp_ptr->resource_parameters_ptr->coap_content_type != 0) {
+            if (resource_temp_ptr->coap_content_type != 0) {
                 *temp_ptr++ = ';';
                 memcpy(temp_ptr, coap_con_type_parameter, COAP_CON_PARAMETER_LEN);
                 temp_ptr += COAP_CON_PARAMETER_LEN;
                 *temp_ptr++ = '"';
-                temp_ptr = sn_nsdl_itoa(temp_ptr, resource_temp_ptr->resource_parameters_ptr->coap_content_type);
+                temp_ptr = sn_nsdl_itoa(temp_ptr,
+                                        resource_temp_ptr->coap_content_type);
                 *temp_ptr++ = '"';
             }
 
             /* ;obs */
              // This needs to be re-visited and may be need an API for maganging obs value for different server implementation
 #ifndef COAP_DISABLE_OBS_FEATURE
-            if (resource_temp_ptr->resource_parameters_ptr->observable) {
+            if (resource_temp_ptr->observable) {
                 *temp_ptr++ = ';';
                 memcpy(temp_ptr, obs_parameter, OBS_PARAMETER_LEN);
                 temp_ptr += OBS_PARAMETER_LEN;
             }
 #endif
-            /* ;aobs;id= */
-            /* todo: aosb not supported ATM */
-            /*
-            if((resource_temp_ptr->resource_parameters_ptr->auto_obs_len > 0 && resource_temp_ptr->resource_parameters_ptr->auto_obs_len <= 8) &&
-                    resource_temp_ptr->resource_parameters_ptr->auto_obs_ptr)
-            {
-                uint8_t i = 0;
-
-                *temp_ptr++ = ';';
-                memcpy(temp_ptr, aobs_parameter, AOBS_PARAMETER_LEN);
-                temp_ptr += AOBS_PARAMETER_LEN;
-
-                while(i < resource_temp_ptr->resource_parameters_ptr->auto_obs_len)
-                {
-                    temp_ptr = sn_nsdl_itoa(temp_ptr, *(resource_temp_ptr->resource_parameters_ptr->auto_obs_ptr + i));
-                    i++;
-                }
-            }
-            */
-
         }
-
         resource_temp_ptr = sn_grs_get_next_resource(handle->grs, resource_temp_ptr);
     }
-
     return SN_NSDL_SUCCESS;
 }
 
@@ -1382,18 +991,17 @@ static uint16_t sn_nsdl_calculate_registration_body_size(struct nsdl_s *handle, 
     /* Local variables */
     uint16_t return_value = 0;
     *error = SN_NSDL_SUCCESS;
-    const sn_nsdl_resource_info_s *resource_temp_ptr;
+    const sn_nsdl_dynamic_resource_parameters_s *resource_temp_ptr;
 
     /* check pointer */
     resource_temp_ptr = sn_grs_get_first_resource(handle->grs);
 
     while (resource_temp_ptr) {
-        if (resource_temp_ptr->resource_parameters_ptr && resource_temp_ptr->publish_uri) {
-            if (updating_registeration && resource_temp_ptr->resource_parameters_ptr->registered == SN_NDSL_RESOURCE_REGISTERED) {
+        if (resource_temp_ptr->publish_uri) {
+            if (updating_registeration && resource_temp_ptr->registered == SN_NDSL_RESOURCE_REGISTERED) {
                 resource_temp_ptr = sn_grs_get_next_resource(handle->grs, resource_temp_ptr);
                 continue;
             }
-
             /* If not first resource, then '.' will be added */
             if (return_value) {
                 if (sn_nsdl_check_uint_overflow(return_value, 1, 0)) {
@@ -1405,8 +1013,10 @@ static uint16_t sn_nsdl_calculate_registration_body_size(struct nsdl_s *handle, 
             }
 
             /* Count length for the resource path </path> */
-            if (sn_nsdl_check_uint_overflow(return_value, 3,resource_temp_ptr->pathlen)) {
-                return_value += (3 + resource_temp_ptr->pathlen);
+            if (sn_nsdl_check_uint_overflow(return_value,
+                                            3,
+                                            resource_temp_ptr->static_resource_parameters->pathlen)) {
+                return_value += (3 + resource_temp_ptr->static_resource_parameters->pathlen);
             } else {
                 *error = SN_NSDL_FAILURE;
                 break;
@@ -1415,10 +1025,17 @@ static uint16_t sn_nsdl_calculate_registration_body_size(struct nsdl_s *handle, 
             /* Count lengths of the attributes */
 
             /* Resource type parameter */
-            if (resource_temp_ptr->resource_parameters_ptr->resource_type_len) {
+            size_t resource_type_len = 0;
+            if (resource_temp_ptr->static_resource_parameters->resource_type_ptr) {
+                resource_type_len = strlen(resource_temp_ptr->static_resource_parameters->resource_type_ptr);
+            }
+
+            if (resource_type_len) {
                 /* ;rt="restype" */
-                if (sn_nsdl_check_uint_overflow(return_value, 6, resource_temp_ptr->resource_parameters_ptr->resource_type_len)) {
-                    return_value += (6 + resource_temp_ptr->resource_parameters_ptr->resource_type_len);
+                if (sn_nsdl_check_uint_overflow(return_value,
+                                                6,
+                                                resource_type_len)) {
+                    return_value += (6 + resource_type_len);
                 } else {
                     *error = SN_NSDL_FAILURE;
                     break;
@@ -1426,19 +1043,25 @@ static uint16_t sn_nsdl_calculate_registration_body_size(struct nsdl_s *handle, 
             }
 
             /* Interface description parameter */
-            if (resource_temp_ptr->resource_parameters_ptr->interface_description_len) {
+            size_t interface_description_len = 0;
+            if (resource_temp_ptr->static_resource_parameters->interface_description_ptr) {
+                interface_description_len = strlen(resource_temp_ptr->static_resource_parameters->interface_description_ptr);
+            }
+            if (interface_description_len) {
                 /* ;if="iftype" */
-                if (sn_nsdl_check_uint_overflow(return_value, 6, resource_temp_ptr->resource_parameters_ptr->interface_description_len)) {
-                    return_value += (6 + resource_temp_ptr->resource_parameters_ptr->interface_description_len);
+                if (sn_nsdl_check_uint_overflow(return_value,
+                                                6,
+                                                interface_description_len)) {
+                    return_value += (6 + interface_description_len);
                 } else {
                     *error = SN_NSDL_FAILURE;
                     break;
                 }
             }
 
-            if (resource_temp_ptr->resource_parameters_ptr->coap_content_type != 0) {
+            if (resource_temp_ptr->coap_content_type != 0) {
                 /* ;if="content" */
-                uint8_t len = sn_nsdl_itoa_len(resource_temp_ptr->resource_parameters_ptr->coap_content_type);
+                uint8_t len = sn_nsdl_itoa_len(resource_temp_ptr->coap_content_type);
                 if (sn_nsdl_check_uint_overflow(return_value, 6, len)) {
                     return_value += (6 + len);
                 } else {
@@ -1448,7 +1071,7 @@ static uint16_t sn_nsdl_calculate_registration_body_size(struct nsdl_s *handle, 
             }
 #ifndef COAP_DISABLE_OBS_FEATURE
             // This needs to be re-visited and may be need an API for maganging obs value for different server implementation
-            if (resource_temp_ptr->resource_parameters_ptr->observable) {
+            if (resource_temp_ptr->observable) {
                 if (sn_nsdl_check_uint_overflow(return_value, 4, 0)) {
                     return_value += 4;
                 } else {
@@ -1819,52 +1442,7 @@ static int8_t sn_nsdl_resolve_ep_information(struct nsdl_s *handle, sn_coap_hdr_
     return SN_NSDL_SUCCESS;
 }
 
-int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint16_t port, sn_nsdl_addr_type_e address_type)
-{
-
-    /* Check parameters and source pointers */
-    if (!handle || !handle->nsp_address_ptr || !handle->nsp_address_ptr->omalw_address_ptr || !NSP_address) {
-        return SN_NSDL_FAILURE;
-    }
-
-    handle->nsp_address_ptr->omalw_address_ptr->type = address_type;
-    handle->nsp_address_ptr->omalw_server_security = SEC_NOT_SET;
-
-    if (address_type == SN_NSDL_ADDRESS_TYPE_IPV4) {
-        if (handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
-            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
-        }
-
-        handle->nsp_address_ptr->omalw_address_ptr->addr_len = 4;
-
-        handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(handle->nsp_address_ptr->omalw_address_ptr->addr_len);
-        if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
-            return SN_NSDL_FAILURE;
-        }
-
-        memcpy(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, NSP_address, handle->nsp_address_ptr->omalw_address_ptr->addr_len);
-        handle->nsp_address_ptr->omalw_address_ptr->port = port;
-    }
-
-    else if (address_type == SN_NSDL_ADDRESS_TYPE_IPV6) {
-        if (handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
-            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
-        }
-
-        handle->nsp_address_ptr->omalw_address_ptr->addr_len = 16;
-
-        handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(handle->nsp_address_ptr->omalw_address_ptr->addr_len);
-        if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
-            return SN_NSDL_FAILURE;
-        }
-
-        memcpy(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, NSP_address, handle->nsp_address_ptr->omalw_address_ptr->addr_len);
-        handle->nsp_address_ptr->omalw_address_ptr->port = port;
-    }
-    return SN_NSDL_SUCCESS;
-}
-
-extern int8_t set_NSP_address_2(struct nsdl_s *handle, uint8_t *NSP_address, uint8_t address_length, uint16_t port, sn_nsdl_addr_type_e address_type)
+extern int8_t set_NSP_address(struct nsdl_s *handle, uint8_t *NSP_address, uint8_t address_length, uint16_t port, sn_nsdl_addr_type_e address_type)
 {
     /* Check parameters and source pointers */
     if (!handle || !handle->nsp_address_ptr || !handle->nsp_address_ptr->omalw_address_ptr || !NSP_address) {
@@ -1932,445 +1510,6 @@ static uint8_t *sn_nsdl_itoa(uint8_t *ptr, uint8_t value)
 
     }
     return (ptr + i);
-}
-
-static int32_t sn_nsdl_atoi(uint8_t *ptr, uint8_t len)
-{
-
-    int32_t result = 0;
-
-    while (len--) {
-
-        if (result) {
-            result *= 10;
-        }
-
-        if (*ptr >= '0' && *ptr <= '9') {
-            result += *ptr - '0';
-        } else{
-            return -1;
-        }
-
-        ptr++;
-
-    }
-    return result;
-
-}
-
-static uint32_t sn_nsdl_ahextoi(uint8_t *ptr, uint8_t len)
-{
-
-    uint32_t result = 0;
-
-    while (len--) {
-
-        if (result) {
-            result *= 16;
-        }
-
-        if (*ptr >= '0' && *ptr <= '9') {
-            result += *ptr - '0';
-        } else if (*ptr >= 'a' && *ptr <= 'f') {
-            result += *ptr - 87;
-        } else if (*ptr >= 'A' && *ptr <= 'F') {
-            result += *ptr - 55;
-        }
-
-        ptr++;
-
-    }
-    return result;
-
-}
-
-static int8_t sn_nsdl_resolve_lwm2m_address(struct nsdl_s *handle, uint8_t *uri, uint16_t uri_len)
-{
-#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-    if( uri_len < 2 ){
-        return SN_NSDL_FAILURE;
-    }
-    uint8_t *temp_ptr = uri+2;
-    uint16_t i = 0;
-    uint8_t char_cnt = 0;
-
-    /* jump over coap// */
-    while ((*(temp_ptr - 2) != '/') || (*(temp_ptr - 1) != '/')) {
-        temp_ptr++;
-        if (temp_ptr - uri >= uri_len) {
-            return SN_NSDL_FAILURE;
-        }
-    }
-
-    /* Resolve address type */
-    /* Count semicolons */
-
-    int8_t endPos = -1;
-
-    while (i < (uri_len - (temp_ptr - uri))) {
-        if (*(temp_ptr + i) == ':') {
-            char_cnt++;
-        }else if(*(temp_ptr + i) == ']'){
-            endPos = i;
-        }
-        i++;
-    }
-
-    uint8_t *temp_pos = temp_ptr; //store starting point in case of IPv4 parsing fails
-
-    /* IPv6 */
-    if (char_cnt > 2) {
-        i = 0;
-
-        if( handle->nsp_address_ptr->omalw_address_ptr->addr_ptr ){
-            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
-        }
-
-        handle->nsp_address_ptr->omalw_address_ptr->type = SN_NSDL_ADDRESS_TYPE_IPV6;
-        handle->nsp_address_ptr->omalw_address_ptr->addr_len = 16;
-        handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(16);
-        if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
-            return SN_NSDL_FAILURE;
-        }
-
-        memset(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, 0, 16);
-        if (*temp_ptr == '[' && endPos > 0 && (temp_ptr - uri) + endPos < uri_len && *(temp_ptr + endPos + 1) == ':') {
-            temp_ptr++;
-            endPos--;
-        }else{
-            /* return failure, because port is mandatory */
-            return SN_NSDL_FAILURE;
-        }
-
-        int8_t loopbackPos = -1;
-        if( char_cnt != 8 ){
-            i = 0;
-            char_cnt -= 1;
-            while( i+1 < endPos ){
-                if(*(temp_ptr + i) == ':' && *(temp_ptr + i+1) == ':') {
-                    loopbackPos = i;
-                    break;
-                }
-                i++;
-            }
-        }
-        i = 0;
-
-        uint8_t numberOfZeros = 8 - char_cnt;
-        if(loopbackPos == 0){
-            numberOfZeros++;
-        }
-
-        if(loopbackPos == endPos-2){
-            numberOfZeros++;
-        }
-
-        /* Resolve address */
-        int8_t pos = loopbackPos == 0?0:-1;
-        while (i < 16 && ((temp_ptr - uri) + char_cnt) < uri_len) {
-            char_cnt = 0;
-            if( pos == loopbackPos ){
-                for( int k=0; k < numberOfZeros; k++ ){
-                    i+=2;
-                }
-                pos+=2;
-                temp_ptr += 2;
-                if( numberOfZeros == 8 ){
-                    temp_ptr++;
-                }
-                continue;
-            }
-            while (*(temp_ptr + char_cnt) != ':' && *(temp_ptr + char_cnt) != ']') {
-                char_cnt++;
-                pos++;
-            }
-            pos++;
-
-            if (char_cnt <= 2) {
-                i++;
-            }
-
-            while (char_cnt) {
-                if (char_cnt % 2) {
-                    *(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr + i) = (uint8_t)sn_nsdl_ahextoi(temp_ptr, 1);
-                    temp_ptr++;
-                    char_cnt --;
-                } else {
-                    *(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr + i) = (uint8_t)sn_nsdl_ahextoi(temp_ptr, 2);
-                    temp_ptr += 2;
-                    char_cnt -= 2;
-                }
-                i++;
-            }
-            temp_ptr++;
-        }
-
-        temp_ptr++;
-        uint16_t handled = (temp_ptr - uri);
-        if( handled < uri_len ){
-            if( *(temp_ptr + (uri_len - (temp_ptr - uri) -1)) == '/' ){
-                handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri) - 1);
-            }else{
-                handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri));
-            }
-        }
-    }
-    /* IPv4 or Hostname */
-    else if (char_cnt == 1) {
-        char_cnt = 0;
-        i = 0;
-
-        if( handle->nsp_address_ptr->omalw_address_ptr->addr_ptr ){
-            handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
-        }
-
-        /* Check address type */
-        while (i < (uri_len - (temp_ptr - uri))) {
-            if (*(temp_ptr + i) == '.') {
-                char_cnt++;
-            }
-            i++;
-        }
-
-        bool parseOk = true;
-
-        /* Try IPv4 first */
-        if (char_cnt == 3) {
-            i = 0;
-            char_cnt = 0;
-
-            handle->nsp_address_ptr->omalw_address_ptr->type = SN_NSDL_ADDRESS_TYPE_IPV4;
-            handle->nsp_address_ptr->omalw_address_ptr->addr_len = 4;
-            handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(4);
-            if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
-                return SN_NSDL_FAILURE;
-            }
-
-            while (parseOk && ((temp_ptr - uri) < uri_len) && *(temp_ptr - 1) != ':') {
-                i++;
-
-                if (*(temp_ptr + i) == ':' || *(temp_ptr + i) == '.') {
-                    int8_t value = (int8_t)sn_nsdl_atoi(temp_ptr, i);
-                    if( value == -1 ){
-                        parseOk = false;
-                        char_cnt = 3;
-                        handle->sn_nsdl_free(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr);
-                        handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = NULL;
-                        break;
-                    }
-                    *(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr + char_cnt) = value;
-                    temp_ptr = temp_ptr + i + 1;
-                    char_cnt++;
-                    i = 0;
-                }
-            }
-            if(parseOk) {
-                if( *(temp_ptr + (uri_len - (temp_ptr - uri) -1)) == '/' ){
-                    handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri) - 1);
-                }else{
-                    handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri));
-                }
-            }
-        }else{
-            parseOk = false;
-        }
-
-        /* Then try Hostname */
-        if(!parseOk) {
-            i = 0;
-            temp_ptr = temp_pos;
-
-            handle->nsp_address_ptr->omalw_address_ptr->type = SN_NSDL_ADDRESS_TYPE_HOSTNAME;
-
-            /* Resolve address length */
-            if (uri_len > 0xff) {
-                return SN_NSDL_FAILURE;
-            }
-
-            while (((temp_ptr - uri) + i < uri_len) && *(temp_ptr + i) != ':') {
-                i++;
-            }
-
-            handle->nsp_address_ptr->omalw_address_ptr->addr_len = i;
-
-            /* Copy address */
-            handle->nsp_address_ptr->omalw_address_ptr->addr_ptr = handle->sn_nsdl_alloc(i);
-            if (!handle->nsp_address_ptr->omalw_address_ptr->addr_ptr) {
-                return SN_NSDL_FAILURE;
-            }
-
-            memcpy(handle->nsp_address_ptr->omalw_address_ptr->addr_ptr, temp_ptr, i);
-
-            temp_ptr += i + 1;
-
-            /* Set port */
-            if( *(temp_ptr + (uri_len - (temp_ptr - uri) - 1)) == '/' ){
-                handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri) - 1);
-            }else{
-                handle->nsp_address_ptr->omalw_address_ptr->port = sn_nsdl_atoi(temp_ptr, uri_len - (temp_ptr - uri));
-            }
-        }
-    } else {
-        return SN_NSDL_FAILURE;
-    }
-
-    return SN_NSDL_SUCCESS;
-#else
-    return SN_NSDL_FAILURE;
-#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-}
-
-
-int8_t sn_nsdl_process_oma_tlv(struct nsdl_s *handle, uint8_t *data_ptr, uint16_t data_len)
-{
-#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-    uint8_t *temp_ptr = data_ptr;
-    uint8_t type = 0;
-    uint16_t identifier = 0;
-    uint32_t length = 0;
-    uint8_t path_temp[5] = "0/0/x";
-
-    sn_nsdl_resource_info_s resource_temp = {
-        .resource_parameters_ptr = 0,
-        .mode = SN_GRS_STATIC,
-        .pathlen = 5,
-        .path = path_temp,
-        .resourcelen = 0,
-        .resource = 0,
-        .access = (sn_grs_resource_acl_e) 0x0f, /* All allowed */
-        .sn_grs_dyn_res_callback = 0
-    };
-
-    while ((temp_ptr - data_ptr) < data_len) {
-        /* Save type for future use */
-        type = *temp_ptr++;
-
-        /* * Bit 5: Indicates the Length of the Identifier. * */
-        if (type & 0x20) {
-            /* 1=The Identifier field of this TLV is 16 bits long */
-            identifier = (uint8_t)(*temp_ptr++) << 8;
-            identifier += (uint8_t) * temp_ptr++;
-        } else {
-            /* 0=The Identifier field of this TLV is 8 bits long */
-            identifier = (uint8_t) * temp_ptr++;
-        }
-
-        /* * Bit 4-3: Indicates the type of Length. * */
-        if ((type & 0x18) == 0) {
-            /* 00 = No length field, the value immediately follows the Identifier field in is of the length indicated by Bits 2-0 of this field */
-            length = (type & 0x07);
-        } else if ((type & 0x18) == 0x08) {
-            /* 01 = The Length field is 8-bits and Bits 2-0 MUST be ignored */
-            length = *temp_ptr++;
-        } else if ((type & 0x18) == 0x10) {
-            /* 10 = The Length field is 16-bits and Bits 2-0 MUST be ignored */
-            length = (uint8_t)(*temp_ptr++) << 8;
-            length += (uint8_t) * temp_ptr++;
-        } else if ((type & 0x18) == 0x18) {
-            /* 11 = The Length field is 24-bits and Bits 2-0 MUST be ignored */
-            length = (uint8_t)(*temp_ptr++);
-            length = length << 16;
-            length += (uint8_t)(*temp_ptr++) << 8;
-            length += (uint8_t) * temp_ptr++;
-        }
-
-        /* * Bits 7-6: Indicates the type of Identifier. * */
-        if ((type & 0xC0) == 0x00) {
-            /* 00 = Object Instance in which case the Value contains one or more Resource TLVs */
-            /* Not implemented, return failure */
-        } else if ((type & 0xC0) == 0xC0) {
-            /* 11 = Resource with Value */
-            switch (identifier) {
-                case 0:
-                    /* Resolve LWM2M Server URI */
-                    sn_nsdl_resolve_lwm2m_address(handle, temp_ptr, length);
-                    path_temp[4] = '0';
-                    resource_temp.resource = temp_ptr;
-                    resource_temp.resourcelen = length;
-                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
-                        return SN_NSDL_FAILURE;
-                    }
-                    break;
-                case 2:
-                    /* Resolve security Mode */
-                    handle->nsp_address_ptr->omalw_server_security = (omalw_server_security_t)sn_nsdl_atoi(temp_ptr, length);
-                    path_temp[4] = '2';
-                    resource_temp.resource = temp_ptr;
-                    resource_temp.resourcelen = length;
-                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
-                        return SN_NSDL_FAILURE;
-                    }
-
-                    break;
-                case 3:
-                    /* Public Key or Identity */
-                    path_temp[4] = '3';
-                    resource_temp.resource = temp_ptr;
-                    resource_temp.resourcelen = length;
-                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
-                        return SN_NSDL_FAILURE;
-                    }
-                    break;
-                case 4:
-                    /* Server Public Key or Identity */
-                    ;
-                    path_temp[4] = '4';
-                    resource_temp.resource = temp_ptr;
-                    resource_temp.resourcelen = length;
-                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
-                        return SN_NSDL_FAILURE;
-                    }
-
-                    break;
-                case 5:
-                    /* Secret Key */
-                    path_temp[4] = '5';
-                    resource_temp.resource = temp_ptr;
-                    resource_temp.resourcelen = length;
-                    if (sn_nsdl_create_resource(handle, &resource_temp) != SN_NSDL_SUCCESS) {
-                        return SN_NSDL_FAILURE;
-                    }
-                    break;
-                default:
-                    break;
-            }
-
-            /* Move pointer to next TLV message */
-            temp_ptr += length;
-        }
-    }
-
-    return SN_NSDL_SUCCESS;
-#else
-    return SN_NSDL_FAILURE;
-#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-}
-
-static void sn_nsdl_check_oma_bs_status(struct nsdl_s *handle)
-{
-#ifndef MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
-    /* Check OMA BS status */
-    if ((handle->nsp_address_ptr->omalw_server_security == PSK) && (handle->nsp_address_ptr->omalw_address_ptr->type != SN_NSDL_ADDRESS_TYPE_NONE)) {
-        /* call cb that oma bootstrap is done */
-        if(handle->sn_nsdl_oma_bs_done_cb != 0){
-            handle->sn_nsdl_oma_bs_done_cb(handle->nsp_address_ptr);
-        }
-        if(handle->sn_nsdl_oma_bs_done_cb_handle != 0){
-            handle->sn_nsdl_oma_bs_done_cb_handle(handle->nsp_address_ptr, handle);
-        }
-
-    } else if ((handle->nsp_address_ptr->omalw_server_security == CERTIFICATE) && (handle->nsp_address_ptr->omalw_address_ptr->type != SN_NSDL_ADDRESS_TYPE_NONE) &&
-               ((sn_nsdl_get_resource(handle, 5, (void *)"0/0/5") != 0) &&
-                (sn_nsdl_get_resource(handle, 5, (void *)"0/0/4") != 0) &&
-                (sn_nsdl_get_resource(handle, 5, (void *)"0/0/3") != 0))) {
-        if( handle->sn_nsdl_oma_bs_done_cb ){
-            handle->sn_nsdl_oma_bs_done_cb(handle->nsp_address_ptr);
-        }
-        if( handle->sn_nsdl_oma_bs_done_cb_handle ){
-            handle->sn_nsdl_oma_bs_done_cb_handle(handle->nsp_address_ptr, handle);
-        }
-    }
-#endif //MBED_CLIENT_DISABLE_BOOTSTRAP_FEATURE
 }
 
 static int8_t set_endpoint_info(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *endpoint_info_ptr)
@@ -2444,7 +1583,8 @@ void sn_nsdl_free_resource_list(struct nsdl_s *handle, sn_grs_resource_list_s *l
     sn_grs_free_resource_list(handle->grs, list);
 }
 
-extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res)
+#ifndef MEMORY_OPTIMIZED_API
+extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
 {
     /* Check parameters */
     if (handle == NULL) {
@@ -2453,6 +1593,17 @@ extern int8_t sn_nsdl_update_resource(struct nsdl_s *handle, sn_nsdl_resource_in
 
     return sn_grs_update_resource(handle->grs, res);
 }
+
+extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
+{
+    /* Check parameters */
+    if (handle == NULL) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return sn_grs_create_resource(handle->grs, res);
+}
+#endif
 
 extern int8_t sn_nsdl_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *address_ptr, sn_coap_hdr_s *coap_hdr_ptr)
 {
@@ -2464,23 +1615,22 @@ extern int8_t sn_nsdl_send_coap_message(struct nsdl_s *handle, sn_nsdl_addr_s *a
     return sn_grs_send_coap_message(handle, address_ptr, coap_hdr_ptr);
 }
 
-extern int8_t sn_nsdl_create_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res)
-{
-    /* Check parameters */
-    if (handle == NULL) {
-        return SN_NSDL_FAILURE;
-    }
-
-    return sn_grs_create_resource(handle->grs, res);
-}
-
-extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_resource_info_s *res)
+extern int8_t sn_nsdl_put_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
 {
     if (!handle) {
         return SN_NSDL_FAILURE;
     }
 
     return sn_grs_put_resource(handle->grs, res);
+}
+
+extern int8_t sn_nsdl_pop_resource(struct nsdl_s *handle, sn_nsdl_dynamic_resource_parameters_s *res)
+{
+    if (!handle) {
+        return SN_NSDL_FAILURE;
+    }
+
+    return sn_grs_pop_resource(handle->grs, res);
 }
 
 extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint16_t pathlen, uint8_t *path)
@@ -2492,7 +1642,7 @@ extern int8_t sn_nsdl_delete_resource(struct nsdl_s *handle, uint16_t pathlen, u
 
     return sn_grs_delete_resource(handle->grs, pathlen, path);
 }
-extern const sn_nsdl_resource_info_s *sn_nsdl_get_first_resource(struct nsdl_s *handle)
+extern const sn_nsdl_dynamic_resource_parameters_s *sn_nsdl_get_first_resource(struct nsdl_s *handle)
 {
     /* Check parameters */
     if (handle == NULL) {
@@ -2501,7 +1651,7 @@ extern const sn_nsdl_resource_info_s *sn_nsdl_get_first_resource(struct nsdl_s *
 
     return sn_grs_get_first_resource(handle->grs);
 }
-extern const sn_nsdl_resource_info_s *sn_nsdl_get_next_resource(struct nsdl_s *handle, const sn_nsdl_resource_info_s *resource)
+extern const sn_nsdl_dynamic_resource_parameters_s *sn_nsdl_get_next_resource(struct nsdl_s *handle, const sn_nsdl_dynamic_resource_parameters_s *resource)
 {
     /* Check parameters */
     if (handle == NULL) {

--- a/source/libNsdl/src/sn_nsdl2.c
+++ b/source/libNsdl/src/sn_nsdl2.c
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 /**
- * \file sn_nsdl.c
+ * \file sn_nsdl2.c
  *
  * \brief Nano service device library
  *
  */
+#ifdef MBED_CLIENT_C_NEW_API
 
 #include <string.h>
 
@@ -1754,3 +1755,6 @@ extern void *sn_nsdl_get_context(const struct nsdl_s * const handle)
     }
     return handle->context;
 }
+
+#endif
+


### PR DESCRIPTION
Another attempt to create PR that can be merged to mbed-os.

This version contains the new API and functionality as separate files, which are selected at compilation time if the "MBED_CLIENT_C_NEW_API" macro is defined. This allows us to modify and develop the sn_nsdl and sn_grs modules as we wish while still maintaining 100% backward compatibility with previous released mbed-client modules.