### PR TITLE
Do not NULL location_ptr in set_endpoint_info.

### DIFF
--- a/source/libNsdl/src/sn_nsdl.c
+++ b/source/libNsdl/src/sn_nsdl.c
@@ -136,9 +136,7 @@ int8_t sn_nsdl_destroy(struct nsdl_s *handle)
             handle->ep_information_ptr->type_ptr = 0;
         }
 
-        if (handle->ep_information_ptr->lifetime_ptr)
-
-        {
+        if (handle->ep_information_ptr->lifetime_ptr) {
             handle->sn_nsdl_free(handle->ep_information_ptr->lifetime_ptr);
             handle->ep_information_ptr->lifetime_ptr = 0;
         }
@@ -2416,9 +2414,6 @@ static int8_t set_endpoint_info(struct nsdl_s *handle, sn_nsdl_ep_parameters_s *
 
     handle->ep_information_ptr->binding_and_mode = endpoint_info_ptr->binding_and_mode;
     handle->ep_information_ptr->ds_register_mode = endpoint_info_ptr->ds_register_mode;
-
-    handle->ep_information_ptr->location_ptr = 0;
-    handle->ep_information_ptr->location_len = 0;
 
     return 0;
 }


### PR DESCRIPTION
This will lead to memory leak in sn_nsdl_set_endpoint_location function.