### PR TITLE
Moving resource and resourcelen from Static struct to dynamic

### DIFF
--- a/nsdl-c/sn_nsdl_lib.h
+++ b/nsdl-c/sn_nsdl_lib.h
@@ -156,8 +156,8 @@ typedef struct sn_nsdl_static_resource_parameters_ {
     char        *interface_description_ptr; /**< Interface description */
 #endif	
     char        *path;                      /**< Resource path */
-    uint8_t     *resource;                  /**< NULL if dynamic resource */
-    uint16_t    resourcelen;                /**< 0 if dynamic resource, resource information in static resource */
+//    uint8_t     *resource;                  /**< NULL if dynamic resource */
+//    uint16_t    resourcelen;                /**< 0 if dynamic resource, resource information in static resource */
     bool        external_memory_block:1;    /**< 0 means block messages are handled inside this library,
                                                  otherwise block messages are passed to application */
     unsigned    mode:2;                     /**< STATIC etc.. */
@@ -177,7 +177,9 @@ typedef struct sn_nsdl_resource_parameters_ {
 #else
     sn_nsdl_static_resource_parameters_s        *static_resource_parameters;
 #endif
+    uint8_t                                     *resource;          /**< NULL if dynamic resource */
     ns_list_link_t                              link;
+    uint16_t                                    resourcelen;        /**< 0 if dynamic resource, resource information in static resource */
     uint16_t                                    coap_content_type;  /**< CoAP content type */
     unsigned                                    access:4;           /**< Allowed operation mode, GET, PUT, etc,
                                                                          TODO! This should be in static struct but current

--- a/source/sn_grs.c
+++ b/source/sn_grs.c
@@ -509,8 +509,8 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
             }
 
             /* Add payload */
-            if (resource_temp_ptr->static_resource_parameters->resourcelen != 0) {
-                response_message_hdr_ptr->payload_len = resource_temp_ptr->static_resource_parameters->resourcelen;
+            if (resource_temp_ptr->resourcelen != 0) {
+                response_message_hdr_ptr->payload_len = resource_temp_ptr->resourcelen;
                 response_message_hdr_ptr->payload_ptr = handle->sn_grs_alloc(response_message_hdr_ptr->payload_len);
 
                 if (!response_message_hdr_ptr->payload_ptr) {
@@ -526,7 +526,7 @@ extern int8_t sn_grs_process_coap(struct nsdl_s *nsdl_handle, sn_coap_hdr_s *coa
                 }
 
                 memcpy(response_message_hdr_ptr->payload_ptr,
-                       resource_temp_ptr->static_resource_parameters->resource,
+                       resource_temp_ptr->resource,
                        response_message_hdr_ptr->payload_len);
             }
             // Add max-age attribute for static resources.
@@ -790,9 +790,9 @@ static int8_t sn_grs_resource_info_free(struct grs_s *handle, sn_nsdl_dynamic_re
                 resource_ptr->static_resource_parameters->path = 0;
             }
 
-            if (resource_ptr->static_resource_parameters->resource) {
-                handle->sn_grs_free(resource_ptr->static_resource_parameters->resource);
-                resource_ptr->static_resource_parameters->resource = 0;
+            if (resource_ptr->resource) {
+                handle->sn_grs_free(resource_ptr->resource);
+                resource_ptr->resource = 0;
             }
 
             handle->sn_grs_free(resource_ptr->static_resource_parameters);


### PR DESCRIPTION
This commit includes
 - Moving resource and resourcelen from static struct to dynamic struct so we can get rid of duplicate
   value and value_length parameter from M2MResourceInstance class saving extra 6 bytes