### PR TITLE
Add inclusion to fix compilation error

### DIFF
--- a/source/include/sn_grs.h
+++ b/source/include/sn_grs.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+#include "sn_nsdl_lib.h"
 
 #define SN_GRS_RESOURCE_ALREADY_EXISTS  -2
 #define SN_GRS_INVALID_PATH             -3


### PR DESCRIPTION
If this line is not added. In our case the following compilation error appears.
```
./mbed-client/mbed-client-c/source/include/sn_grs.h:49:22: error: unknown type name 'sn_nsdl_dynamic_resource_parameters_s'
```